### PR TITLE
Fix issue in delete archive method

### DIFF
--- a/lib/open_tok/open_tok_sdk.rb
+++ b/lib/open_tok/open_tok_sdk.rb
@@ -131,7 +131,6 @@ module OpenTok
     def delete_archive( aid, token )
       deleteURL = "/hl/archive/delete/#{aid}"
       doc = do_request( deleteURL, {:test => 'none'}, token )
-      p doc, deleteURL, token
       errors = doc.get_elements('Errors')
       if doc.get_elements('Errors').empty?
         #error = errors[0].get_elements('error')[0]


### PR DESCRIPTION
Found a syntax error while using the delete_archive method in the SDK.  It turned out to be a syntax error.
