### PR TITLE
Add HTTP default_timeout

### DIFF
--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -6,6 +6,7 @@ module OpenTok
   # @private For internal use by the SDK.
   class Client
     include HTTParty
+    default_timeout 1 # Set HTTParty default timeout (open/read) to 1 second
     # TODO: expose a setting for http debugging for developers
     # debug_output $stdout
 

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -6,7 +6,9 @@ module OpenTok
   # @private For internal use by the SDK.
   class Client
     include HTTParty
+
     default_timeout 1 # Set HTTParty default timeout (open/read) to 1 second
+
     # TODO: expose a setting for http debugging for developers
     # debug_output $stdout
 
@@ -29,6 +31,8 @@ module OpenTok
       else
         raise OpenTokError, "Failed to create session. Response code: #{response.code}"
       end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
     def start_archive(session_id, opts)
@@ -52,6 +56,8 @@ module OpenTok
       else
         raise OpenTokArchiveError, "The archive could not be started"
       end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
     def get_archive(archive_id)
@@ -66,6 +72,8 @@ module OpenTok
       else
         raise OpenTokArchiveError, "The archive could not be retrieved."
       end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
     def list_archives(offset, count)
@@ -83,6 +91,8 @@ module OpenTok
       else
         raise OpenTokArchiveError, "The archives could not be retrieved."
       end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
     def stop_archive(archive_id)
@@ -104,6 +114,8 @@ module OpenTok
       else
         raise OpenTokArchiveError, "The archive could not be started."
       end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
     def delete_archive(archive_id)
@@ -120,7 +132,8 @@ module OpenTok
       else
         raise OpenTokArchiveError, "The archive could not be deleted."
       end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
-
   end
 end

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -99,4 +99,14 @@ describe OpenTok::Archives do
     end
   end
 
+  context "http client errors" do
+    before(:each) do
+      stub_request(:get, /.*\/v2\/partner.*/).to_timeout
+    end
+
+    subject { -> { archives.all } }
+
+    it { should raise_error(OpenTok::OpenTokError) }
+  end
+
 end

--- a/spec/opentok/opentok_spec.rb
+++ b/spec/opentok/opentok_spec.rb
@@ -88,7 +88,6 @@ describe OpenTok::OpenTok do
         expect(session.media_mode).to eq :relayed
         expect(session.location).to eq nil
       end
-
     end
 
     context "with an api_key that's a number" do
@@ -121,7 +120,19 @@ describe OpenTok::OpenTok do
       # TODO: i don't need to run all the tests, just a set that checks for the URL's effect
       # include_examples "generates tokens"
     end
+  end
 
+  context "http client errors" do
+    let(:api_key) { "123456" }
+    let(:api_secret) { "1234567890abcdef1234567890abcdef1234567890" }
+
+    before(:each) do
+      stub_request(:post, 'https://api.opentok.com/session/create').to_timeout
+    end
+
+    subject { -> { opentok.create_session } }
+
+    it { should raise_error(OpenTok::OpenTokError) }
   end
 
   # ah, the magic of duck typing. the errors raised don't have any specific description

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "vcr"
+require 'webmock/rspec'
 
 VCR.configure do |c|
   c.cassette_library_dir     = 'spec/cassettes'


### PR DESCRIPTION
Simply adds a default timeout (connect / read) to `HTTParty` to ensure clients don't get unexpected delays in case of network issues. 

I do think it's a very rare event, but given:
* HTTParty supports the option well enough
* There doesn't seem to be an easy way to set this from the outside of the class

I though I would just add the change and open a PR with you guys.

I'm not sure how to spec this out though, I could mock timeouts but that's probably not exactly what I want as it would just mock the exception and not the _actual_ waiting period.

Thoughts from you guys?