### PR TITLE
adds `rake console` command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,9 @@ YARD::Rake::YardocTask.new do |t|
   # t.options = ['--any', '--extra', '--opts'] # optional
 end
 
+desc "Open an irb session preloaded with this library"
+task :console do
+  sh "irb -rubygems -I lib -r opentok.rb"
+end
+
 task :default => :spec


### PR DESCRIPTION
allows developer to start an irb session with the library preloaded