### PR TITLE
Expose JSON object in archive

### DIFF
--- a/lib/opentok/archive.rb
+++ b/lib/opentok/archive.rb
@@ -56,6 +56,9 @@ module OpenTok
       @json = json
     end
 
+    # A JSON encoded representation of the archive
+    attr_reader :json
+
     # A JSON encoded string representation of the archive
     def to_json
       @json.to_json


### PR DESCRIPTION
Avoids having to parse stringified JSON on archives. Currently have to perform the following as a client of Opentok-Ruby-SDK 

````ruby
require 'json'

archive = opentok.archives.find archive_id
actual_json = JSON.parse(archive.to_json) 
````

The existing method signature, to_json, is a bit confusing, since it returns stringified JSON. JSON is supported in a stdlib so I was expecting it to return a JSON object.

As a client of Opentok-Ruby-SDK I could now perform

````ruby
archive = opentok.archives.find archive_id
actual_json = archive.json
````
