### PR TITLE
Change default_timeout to open_timeout and bump timeout to 2s

### DIFF
--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -7,7 +7,7 @@ module OpenTok
   class Client
     include HTTParty
 
-    default_timeout 1 # Set HTTParty default timeout (open/read) to 1 second
+    open_timeout 2 # Set HTTParty default timeout (open/read) to 2 seconds
 
     # TODO: expose a setting for http debugging for developers
     # debug_output $stdout


### PR DESCRIPTION
As raised in https://github.com/opentok/Opentok-Ruby-SDK/issues/105, this PR replaces the default_timeout (open/read) with open_timeout only. 

Given that some issues have been reported from places with extremely poor bandwidth , it also bumps the timeout to 2s.