### PR TITLE
 code coverage with coveralls.io #51 

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in opentok.gemspec
 gemspec
+
+gem 'simplecov', :require => false, :group => :test
+gem 'coveralls', :require => false

--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", "~> 0.8.7"
   # TODO: exclude this for compatibility with rbx
   # spec.add_development_dependency "debugger", "~> 1.6.6"
-	spec.add_development_dependency 'coveralls'
 	
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
   spec.add_dependency "httparty", "~> 0.13.1"

--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", "~> 0.8.7"
   # TODO: exclude this for compatibility with rbx
   # spec.add_development_dependency "debugger", "~> 1.6.6"
-
+	spec.add_development_dependency 'coveralls'
+	
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
   spec.add_dependency "httparty", "~> 0.13.1"
   spec.add_dependency "activesupport", ">= 2.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,10 @@
 require "vcr"
 require 'webmock/rspec'
 
+require 'simplecov'
 require 'coveralls'
+
+SimpleCov.start
 Coveralls.wear!
 
 VCR.configure do |c|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 require "vcr"
 require 'webmock/rspec'
 
+require 'coveralls'
+Coveralls.wear!
+
 VCR.configure do |c|
   c.cassette_library_dir     = 'spec/cassettes'
   c.hook_into                :webmock


### PR DESCRIPTION
- add gem to gemspec
- add require 'coveralls' to spec_helper
- specify service name in .coveralls.yml

The next time project builds on Travis simplecov should send data to coverall. 

> I am not sure whether coverall and simplecov could be used in gemspec or it would be better to leave them in Gemfile.
