### PR TITLE
Wrapper method for connection force disconnect endpoint

### DIFF
--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -38,6 +38,26 @@ module OpenTok
       raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
+    def disconnection_connection(session_id, connection_id)
+      response = self.class.delete("/v2/partner/#{@api_key}/session/#{session_id}/connection/#{connection_id}", {
+        :headers => { "Content-Type" => "application/json" }
+      })
+      case response.code
+      when 204
+        response
+      when 403
+        raise OpenTokAuthenticationError, "You are not authorized to forceDisconnect, check your authentication credentials. API Key: #{@api_key}, Session ID: #{session_id}"
+      when 400
+        raise OpenTokError, "One of the arguments — sessionId or connectionId — is invalid."
+      when 404
+        raise OpenTokError, "The client specified by the connectionId property is not connected to the session."
+      else
+        raise OpenTokError, "Failed to disconect the connection. Response code: #{response.code}"
+      end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
+    end
+
     def start_archive(session_id, opts)
       opts.extend(HashExtensions)
       body = { "sessionId" => session_id }.merge(opts.camelize_keys!)

--- a/lib/opentok/connection.rb
+++ b/lib/opentok/connection.rb
@@ -1,0 +1,29 @@
+require "opentok/client"
+require "opentok/archive"
+require "opentok/archive_list"
+
+module OpenTok
+  # A class for working with OpenTok connections.
+  class Connection
+
+    # @private
+    def initialize(client)
+      @client = client
+    end
+
+    # Force disconnects an OpenTok connection.
+    #
+    # @param [String] session_id The session ID of the connection you want to disconect.
+    # @param [String] connection_id The connection ID of the connection you want to disconect.
+    #
+    # @raise [OpenTokAuthenticationError] Authentication failed.
+    # @raise [OpenTokError] The session ID/connection ID is invalid or does not exist.
+    def delete_by_id(session_id, connection_id)
+      raise ArgumentError, "session_id not provided" if session_id.to_s.empty?
+      raise ArgumentError, "connection_id not provided" if connection_id.to_s.empty?
+      response = @client.disconnection_connection(session_id, connection_id)
+      (200..300).include? response.code
+    end
+
+  end
+end

--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -3,6 +3,7 @@ require "opentok/session"
 require "opentok/client"
 require "opentok/token_generator"
 require "opentok/archives"
+require "opentok/connection"
 
 require "resolv"
 require "set"
@@ -170,6 +171,11 @@ module OpenTok
     # An Archives object, which lets you work with OpenTok archives.
     def archives
       @archives ||= Archives.new client
+    end
+
+    # A Connection object, which lets you work with OpenTok connections.
+    def connection
+      @connection ||= Connection.new client
     end
 
     protected


### PR DESCRIPTION
The session moderation REST APIs are not supported by this wrapper. 

This PR adds support for the [connection deletion (force disconnect) endpoint](https://www.tokbox.com/developer/rest/#forceDisconnect). I needed this particular feature for a project, hopefully this spurs a more thorough effort to support the various connection-based APIs.