### PR TITLE
Update REST API URL from /partner to /project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 - 2.0.0
 - 2.1.0
 - 2.2.0
-- rbx-2
+- 2.4.0
 notifications:
   slack:
     secure: agVll2R9PTPvJMcUgbvOh9eGt60zGDc8kPUwEsiQr828rCgXh/ZxD5irYDyKQg3ZsS8+f3MjFCwzU7uQALkia2pDrie9d8g8m1dt4Q5U7Qm6QecshvE0U9JwbB5Ngxaftbqyf0XEFrE7CKs7RI1BzFRpe8m+fdZgfwccX8Gb7pc=

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -41,7 +41,7 @@ module OpenTok
     def start_archive(session_id, opts)
       opts.extend(HashExtensions)
       body = { "sessionId" => session_id }.merge(opts.camelize_keys!)
-      response = self.class.post("/v2/partner/#{@api_key}/archive", {
+      response = self.class.post("/v2/project/#{@api_key}/archive", {
         :body => body.to_json,
         :headers => { "Content-Type" => "application/json" }
       })
@@ -64,7 +64,7 @@ module OpenTok
     end
 
     def get_archive(archive_id)
-      response = self.class.get("/v2/partner/#{@api_key}/archive/#{archive_id}")
+      response = self.class.get("/v2/project/#{@api_key}/archive/#{archive_id}")
       case response.code
       when 200
         response
@@ -83,7 +83,7 @@ module OpenTok
       query = Hash.new
       query[:offset] = offset unless offset.nil?
       query[:count] = count unless count.nil?
-      response = self.class.get("/v2/partner/#{@api_key}/archive", {
+      response = self.class.get("/v2/project/#{@api_key}/archive", {
         :query => query.empty? ? nil : query
       })
       case response.code
@@ -99,7 +99,7 @@ module OpenTok
     end
 
     def stop_archive(archive_id)
-      response = self.class.post("/v2/partner/#{@api_key}/archive/#{archive_id}/stop", {
+      response = self.class.post("/v2/project/#{@api_key}/archive/#{archive_id}/stop", {
         :headers => { "Content-Type" => "application/json" }
       })
       case response.code
@@ -121,7 +121,7 @@ module OpenTok
     end
 
     def delete_archive(archive_id)
-      response = self.class.delete("/v2/partner/#{@api_key}/archive/#{archive_id}", {
+      response = self.class.delete("/v2/project/#{@api_key}/archive/#{archive_id}", {
         :headers => { "Content-Type" => "application/json" }
       })
       case response.code

--- a/spec/cassettes/OpenTok_Archives/should_create_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_archives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.opentok.com/v2/partner/123456/archive
+    uri: https://api.opentok.com/v2/project/123456/archive
     body:
       encoding: UTF-8
       string: '{"sessionId":"SESSIONID"}'

--- a/spec/cassettes/OpenTok_Archives/should_create_audio_only_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_audio_only_archives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.opentok.com/v2/partner/123456/archive
+    uri: https://api.opentok.com/v2/project/123456/archive
     body:
       encoding: UTF-8
       string: '{"sessionId":"SESSIONID","hasVideo":false}'

--- a/spec/cassettes/OpenTok_Archives/should_create_individual_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_individual_archives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.opentok.com/v2/partner/123456/archive
+    uri: https://api.opentok.com/v2/project/123456/archive
     body:
       encoding: UTF-8
       string: '{"sessionId":"SESSIONID","outputMode":"individual"}'

--- a/spec/cassettes/OpenTok_Archives/should_create_named_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_named_archives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.opentok.com/v2/partner/123456/archive
+    uri: https://api.opentok.com/v2/project/123456/archive
     body:
       encoding: UTF-8
       string: '{"sessionId":"SESSIONID","name":"ARCHIVE NAME"}'

--- a/spec/cassettes/OpenTok_Archives/should_delete_an_archive_by_id.yml
+++ b/spec/cassettes/OpenTok_Archives/should_delete_an_archive_by_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.opentok.com/v2/partner/123456/archive/832641bf-5dbf-41a1-ad94-fea213e59a92
+    uri: https://api.opentok.com/v2/project/123456/archive/832641bf-5dbf-41a1-ad94-fea213e59a92
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/OpenTok_Archives/should_find_archives_by_id.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_archives_by_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.opentok.com/v2/partner/123456/archive/f6e7ee58-d6cf-4a59-896b-6d56b158ec71
+    uri: https://api.opentok.com/v2/project/123456/archive/f6e7ee58-d6cf-4a59-896b-6d56b158ec71
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/OpenTok_Archives/should_find_archives_with_unknown_properties.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_archives_with_unknown_properties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.opentok.com/v2/partner/123456/archive/f6e7ee58-d6cf-4a59-896b-6d56b158ec71
+    uri: https://api.opentok.com/v2/project/123456/archive/f6e7ee58-d6cf-4a59-896b-6d56b158ec71
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/OpenTok_Archives/should_find_expired_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_expired_archives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.opentok.com/v2/partner/123456/archive/f6e7ee58-d6cf-4a59-896b-6d56b158ec71
+    uri: https://api.opentok.com/v2/project/123456/archive/f6e7ee58-d6cf-4a59-896b-6d56b158ec71
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/OpenTok_Archives/should_find_paused_archives_by_id.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_paused_archives_by_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.opentok.com/v2/partner/123456/archive/f6e7ee58-d6cf-4a59-896b-6d56b158ec71
+    uri: https://api.opentok.com/v2/project/123456/archive/f6e7ee58-d6cf-4a59-896b-6d56b158ec71
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/OpenTok_Archives/should_stop_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_stop_archives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.opentok.com/v2/partner/123456/archive/30b3ebf1-ba36-4f5b-8def-6f70d9986fe9/stop
+    uri: https://api.opentok.com/v2/project/123456/archive/30b3ebf1-ba36-4f5b-8def-6f70d9986fe9/stop
     headers:
       X-Tb-Partner-Auth:
       - 123456:1234567890abcdef1234567890abcdef1234567890

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_all_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_all_archives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.opentok.com/v2/partner/123456/archive
+    uri: https://api.opentok.com/v2/project/123456/archive
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_archives_with_an_offset.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_archives_with_an_offset.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.opentok.com/v2/partner/123456/archive?offset=3
+    uri: https://api.opentok.com/v2/project/123456/archive?offset=3
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_count_number_of_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_count_number_of_archives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.opentok.com/v2/partner/123456/archive?count=2
+    uri: https://api.opentok.com/v2/project/123456/archive?count=2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_part_of_the_archives_when_using_offset_and_count.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_part_of_the_archives_when_using_offset_and_count.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.opentok.com/v2/partner/123456/archive?count=4&offset=2
+    uri: https://api.opentok.com/v2/project/123456/archive?count=4&offset=2
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
/partner is deprecated and will no longer by supported from July 2017