### PR TITLE
Support filtering by session ID #126

### DIFF
--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -100,7 +100,9 @@ module OpenTok
     # @return [ArchiveList] An ArchiveList object, which is an array of Archive objects.
     def all(options = {})
       raise ArgumentError, "Limit is invalid" unless options[:count].nil? or (0..100).include? options[:count]
-      archive_list_json = @client.list_archives(options[:offset], options[:count])
+      archive_list_json = @client.list_archives(options[:offset],
+                                                options[:count],
+                                                options[:session_id])
       ArchiveList.new self, archive_list_json
     end
 

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -79,10 +79,11 @@ module OpenTok
       raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
-    def list_archives(offset, count)
+    def list_archives(offset, count, session_id = nil)
       query = Hash.new
       query[:offset] = offset unless offset.nil?
       query[:count] = count unless count.nil?
+      query[:sessionId] = session_id unless session_id.nil?
       response = self.class.get("/v2/project/#{@api_key}/archive", {
         :query => query.empty? ? nil : query
       })

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_session_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_session_archives.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/archive?sessionId=SESSIONID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Tb-Partner-Auth:
+      - 123456:1234567890abcdef1234567890abcdef1234567890
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Mar 2017 00:44:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 6,
+          "items" : [ {
+            "createdAt" : 1395183243000,
+            "duration" : 544,
+            "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+            "name" : "",
+            "partnerId" : 123456,
+            "reason" : "",
+            "sessionId" : "SESSIONID",
+            "size" : 78499758,
+            "status" : "available",
+            "url" : "http://tokbox.com.archive2.s3.amazonaws.com/123456%2F30b3ebf1-ba36-4f5b-8def-6f70d9986fe9%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          }, {
+            "createdAt" : 1394396753000,
+            "duration" : 24,
+            "id" : "b8f64de1-e218-4091-9544-4cbf369fc238",
+            "name" : "showtime again",
+            "partnerId" : 123456,
+            "reason" : "",
+            "sessionId" : "SESSIONID",
+            "size" : 2227849,
+            "status" : "available",
+            "url" : "http://tokbox.com.archive2.s3.amazonaws.com/123456%2Fb8f64de1-e218-4091-9544-4cbf369fc238%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          }, {
+            "createdAt" : 1394321113000,
+            "duration" : 1294,
+            "id" : "832641bf-5dbf-41a1-ad94-fea213e59a92",
+            "name" : "showtime",
+            "partnerId" : 123456,
+            "reason" : "",
+            "sessionId" : "SESSIONID",
+            "size" : 42165242,
+            "status" : "available",
+            "url" : "http://tokbox.com.archive2.s3.amazonaws.com/123456%2F832641bf-5dbf-41a1-ad94-fea213e59a92%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          } ]
+        }
+    http_version:
+  recorded_at: Wed, 19 Mar 2017 00:44:22 GMT
+recorded_with: VCR 2.8.0

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -119,6 +119,12 @@ describe OpenTok::Archives do
       expect(archive_list).to be_an_instance_of OpenTok::ArchiveList
       expect(archive_list.count).to eq 4
     end
+
+    it "should return session archives", :vcr => { :erb => { :version => OpenTok::VERSION } } do
+      archive_list = archives.all :session_id => session_id
+      expect(archive_list).to be_an_instance_of OpenTok::ArchiveList
+      expect(archive_list.total).to eq 6
+    end
   end
 
   context "http client errors" do


### PR DESCRIPTION
Ability to query archives by session id. #126 

`OpenTokAdapter.client.archives.all(session_id: 'SESSIONID')`