### PR TITLE
List archives by session id

### DIFF
--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -96,11 +96,13 @@ module OpenTok
     #   the most recent archive. If you do not specify an offset, 0 is used.
     # @option options [integer] :count Optional. The number of archives to be returned. The maximum
     #   number of archives returned is 1000.
+    # @option options [string] :session_id Optional. The session id of the archives. This is useful
+    #   when listing multiple archives for an automatically archived session.
     #
     # @return [ArchiveList] An ArchiveList object, which is an array of Archive objects.
     def all(options = {})
       raise ArgumentError, "Limit is invalid" unless options[:count].nil? or (0..100).include? options[:count]
-      archive_list_json = @client.list_archives(options[:offset], options[:count])
+      archive_list_json = @client.list_archives(options[:offset], options[:count], options[:session_id])
       ArchiveList.new self, archive_list_json
     end
 

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -79,10 +79,11 @@ module OpenTok
       raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
-    def list_archives(offset, count)
+    def list_archives(offset, count, session_id)
       query = Hash.new
       query[:offset] = offset unless offset.nil?
       query[:count] = count unless count.nil?
+      query[:sessionId] = session_id unless session_id.nil?
       response = self.class.get("/v2/project/#{@api_key}/archive", {
         :query => query.empty? ? nil : query
       })

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_part_of_the_archives_when_using_session_id.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_part_of_the_archives_when_using_session_id.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/archive?sessionId=abc-123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Tb-Partner-Auth:
+      - 123456:1234567890abcdef1234567890abcdef1234567890
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Mar 2014 00:57:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 1,
+          "items" : [ {
+            "createdAt" : 1395187836000,
+            "duration" : 62,
+            "id" : "f6e7ee58-d6cf-4a59-896b-6d56b158ec71",
+            "name" : "",
+            "partnerId" : 123456,
+            "reason" : "",
+            "sessionId" : "abc-123",
+            "size" : 8347554,
+            "status" : "available",
+            "url" : "http://tokbox.com.archive2.s3.amazonaws.com/123456%2Ff6e7ee58-d6cf-4a59-896b-6d56b158ec71%2Farchive.mp4?Expires=1395188695&AWSAccessKeyId=AKIAI6LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 19 Mar 2014 00:57:50 GMT
+recorded_with: VCR 2.8.0

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -119,6 +119,12 @@ describe OpenTok::Archives do
       expect(archive_list).to be_an_instance_of OpenTok::ArchiveList
       expect(archive_list.count).to eq 4
     end
+
+    it "should return part of the archives when using session_id", :vcr => { :erb => { :version => OpenTok::VERSION } } do
+      archive_list = archives.all :session_id => "abc-123"
+      expect(archive_list).to be_an_instance_of OpenTok::ArchiveList
+      expect(archive_list.count).to eq 1
+    end
   end
 
   context "http client errors" do


### PR DESCRIPTION
This is necessary to retrieve archives from automatically archived
session.

Reference:
https://tokbox.com/developer/rest/#listing_archives