### PR TITLE
Remove gsubbery and uses Ruby's Base64.urlsafe_decode64 instead when …

### DIFF
--- a/lib/opentok/session.rb
+++ b/lib/opentok/session.rb
@@ -59,9 +59,7 @@ module OpenTok
     # that is intentional, that is too much responsibility.
     def self.belongs_to_api_key?(session_id, api_key)
       encoded = session_id[2..session_id.length]
-                          .gsub('-', '+')
-                          .gsub('_', '/')
-      decoded = Base64.decode64(encoded)
+      decoded = Base64.urlsafe_decode64(encoded)
       decoded.include? api_key
     end
 


### PR DESCRIPTION
…decoding session_id.

`Base64.urlsafe_decode64` comes with Ruby since 1.9.1