### PR TITLE
Update opentok.gemspec

### DIFF
--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "debugger", "~> 1.6.6"
 
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
-  spec.add_dependency "httparty", "~> 0.13.1"
+  spec.add_dependency "httparty", ">= 0.13.1"
   spec.add_dependency "activesupport", ">= 2.0"
   spec.add_dependency "jwt", "~> 1.5.6"
 end


### PR DESCRIPTION
To avoid potential dependency conflict:
```
/Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:2288:in `raise_if_conflicts': Unable to activate httparty-0.13.7, because json-2.1.0 conflicts with json (~> 1.8) (Gem::ConflictError)
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1408:in `activate'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1442:in `block in activate_dependencies'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1428:in `each'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1428:in `activate_dependencies'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb:1410:in `activate'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems.rb:220:in `rescue in try_activate'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems.rb:213:in `try_activate'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:126:in `rescue in require'
	from /Users/lucas/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from app.rb:4:in `<main>'
```