### PR TITLE
downgraded httparty for ruby 1.9.3 support. w/ burnettk

### DIFF
--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "debugger", "~> 1.6.6"
 
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
-  spec.add_dependency "httparty", "~> 0.15.5"
+  spec.add_dependency "httparty", "~> 0.14.0"
   spec.add_dependency "activesupport", ">= 2.0"
   spec.add_dependency "jwt", "~> 1.5.6"
 end


### PR DESCRIPTION
We noticed that newer httparty does not seem strictly required. Downgrading it allows us to use the newest version of this gem in ruby 1.9.3.