### PR TITLE
Adds methods to find a session by it's session_id

### DIFF
--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -87,6 +87,12 @@ module OpenTok
       Archive.new self, archive_json
     end
 
+    def find_by_session_id(session_id)
+      raise ArgumentError, "session_id not provided" if session_id.to_s.empty?
+      archive_json = @client.get_archive_by_session_id(session_id.to_s)
+      Archive.new self, archive_json
+    end
+
     # Returns an ArchiveList, which is an array of archives that are completed and in-progress,
     # for your API key.
     #

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -104,7 +104,7 @@ module OpenTok
     end
 
     def get_archive_by_session_id(session_id)
-      response = self.class.get("/v2/project/#{@api_key}/archive/#{archive_id}?sessionId=#{session_id}", {
+      response = self.class.get("/v2/project/#{@api_key}/archive/#{session_id}?sessionId=#{session_id}", {
         :headers => generate_headers
       })
       case response.code

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -20,7 +20,7 @@ module OpenTok
     def initialize(api_key, api_secret, api_url, ua_addendum="")
       self.class.base_uri api_url
       self.class.headers({
-        "User-Agent" => "OpenTok-Ruby-SDK/#{VERSION}" + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" + (ua_addendum ? " #{ua_addendum}" : "")        
+        "User-Agent" => "OpenTok-Ruby-SDK/#{VERSION}" + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" + (ua_addendum ? " #{ua_addendum}" : "")
       })
       @api_key = api_key
       @api_secret = api_secret
@@ -94,6 +94,24 @@ module OpenTok
         response
       when 400
         raise OpenTokArchiveError, "The archive could not be retrieved. The Archive ID was invalid: #{archive_id}"
+      when 403
+        raise OpenTokAuthenticationError, "Authentication failed while retrieving an archive. API Key: #{@api_key}"
+      else
+        raise OpenTokArchiveError, "The archive could not be retrieved."
+      end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
+    end
+
+    def get_archive_by_session_id(session_id)
+      response = self.class.get("/v2/project/#{@api_key}/archive/#{archive_id}?sessionId=#{session_id}", {
+        :headers => generate_headers
+      })
+      case response.code
+      when 200
+        response
+      when 400
+        raise OpenTokArchiveError, "The archive could not be retrieved. The Session ID was invalid: #{session_id}"
       when 403
         raise OpenTokAuthenticationError, "Authentication failed while retrieving an archive. API Key: #{@api_key}"
       else


### PR DESCRIPTION
This PR addresses issue #169 

Simply adds a method of `find_by_session_id` as well as a `get_archive_by_session_id` respectively. 

I followed the [OpenTok REST API reference](https://tokbox.com/developer/rest/#listing_archives) to implement this feature. 