### PR TITLE
Update JWT dependency to 2.1

### DIFF
--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
   spec.add_dependency "httparty", "~> 0.15.5"
   spec.add_dependency "activesupport", ">= 2.0"
-  spec.add_dependency "jwt", "~> 1.5.6"
+  spec.add_dependency "jwt", "~> 2.1"
 end

--- a/spec/cassettes/OpenTok_Archives/calls_layout_on_archive_object.yml
+++ b/spec/cassettes/OpenTok_Archives/calls_layout_on_archive_object.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/changes_the_layout_of_an_archive.yml
+++ b/spec/cassettes/OpenTok_Archives/changes_the_layout_of_an_archive.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Archives/should_create_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_archives.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Archives/should_create_audio_only_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_audio_only_archives.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Archives/should_create_hd_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_hd_archives.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Archives/should_create_individual_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_individual_archives.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Archives/should_create_named_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_named_archives.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Archives/should_delete_an_archive_by_id.yml
+++ b/spec/cassettes/OpenTok_Archives/should_delete_an_archive_by_id.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Archives/should_find_archives_by_id.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_archives_by_id.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_find_archives_with_unknown_properties.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_archives_with_unknown_properties.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_find_expired_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_expired_archives.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_find_paused_archives_by_id.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_paused_archives_by_id.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_stop_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_stop_archives.yml
@@ -7,7 +7,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_all_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_all_archives.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_archives_with_an_offset.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_archives_with_an_offset.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_count_number_of_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_count_number_of_archives.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_part_of_the_archives_when_using_offset_and_count.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_part_of_the_archives_when_using_offset_and_count.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_session_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_session_archives.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Broadcasts/calls_layout_on_broadcast_object.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/calls_layout_on_broadcast_object.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Broadcasts/changes_the_layout_of_a_broadcast.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/changes_the_layout_of_a_broadcast.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Broadcasts/fetches_a_hls_broadcast_url.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/fetches_a_hls_broadcast_url.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Broadcasts/finds_a_broadcast.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/finds_a_broadcast.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Broadcasts/starts_a_rtmp_broadcast.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/starts_a_rtmp_broadcast.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Broadcasts/stops_a_broadcast.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/stops_a_broadcast.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Connections/forces_a_connection_to_be_terminated.yml
+++ b/spec/cassettes/OpenTok_Connections/forces_a_connection_to_be_terminated.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_default_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_default_sessions.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_for_invalid_media_modes.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_for_invalid_media_modes.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_with_a_location_hint.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_with_a_location_hint.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions_with_a_location_hint.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions_with_a_location_hint.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_sessions_with_a_location_hint.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_sessions_with_a_location_hint.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/with_an_addendum_to_the_user_agent_string/should_append_the_addendum_to_the_user_agent_header.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/with_an_addendum_to_the_user_agent_string/should_append_the_addendum_to_the_user_agent_header.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %> BOOYAH
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Signals/receives_a_valid_response_for_a_connection.yml
+++ b/spec/cassettes/OpenTok_Signals/receives_a_valid_response_for_a_connection.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Signals/receives_a_valid_response_for_all_connections.yml
+++ b/spec/cassettes/OpenTok_Signals/receives_a_valid_response_for_all_connections.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Sip/receives_a_valid_response.yml
+++ b/spec/cassettes/OpenTok_Sip/receives_a_valid_response.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Streams/get_all_streams_information.yml
+++ b/spec/cassettes/OpenTok_Streams/get_all_streams_information.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Streams/get_specific_stream_information.yml
+++ b/spec/cassettes/OpenTok_Streams/get_specific_stream_information.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:

--- a/spec/cassettes/OpenTok_Streams/layout_working_on_two_stream_list.yml
+++ b/spec/cassettes/OpenTok_Streams/layout_working_on_two_stream_list.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.Oh_JHhtEUKK1pPV4s6neXJj_RXI8EcEpJRRpG_2c9U0
+      - eyJhbGciOiJIUzI1NiIsImlzdCI6InByb2plY3QifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.LlBVnppHqBiUIl7t_ybzDmvDdv7z8udvN_P8_Oulj_4
       Content-Type:
       - application/json
   response:


### PR DESCRIPTION
This is my first pull request, so let me know if I'm missing anything.

This pull request is based on #182

I would have been more permissible with the version, but the JWT token used in specs is hardcoded, and different versions of JWT generate a different token, which would cause the specs to fail. I do not know how to extract the hard-coded token and generate one with a runtime-determined version.