### PR TITLE
Updated HTTParty to 0.16.3 and all tests pass

### DIFF
--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "debugger", "~> 1.6.6"
 
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
-  spec.add_dependency "httparty", "~> 0.15.5"
+  spec.add_dependency "httparty", "~> 0.16.3"
   spec.add_dependency "activesupport", ">= 2.0"
   spec.add_dependency "jwt", "~> 1.5.6"
 end


### PR DESCRIPTION
Needed to update HTTParty to 0.16.3 in a project because of some improvements of their gem, but it doesn't affects the OpenTok gem.