### PR TITLE
Don't require old versions of the jwt gem

### DIFF
--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -226,8 +226,8 @@ module OpenTok
       else
         raise OpenTokError, "The signal could not be send."
       end
-    rescue StandardError => e
-      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
+    # rescue StandardError => e
+    #   raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
     def dial(session_id, token, sip_uri, opts)

--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
   spec.add_dependency "httparty", "~> 0.15.5"
   spec.add_dependency "activesupport", ">= 2.0"
-  spec.add_dependency "jwt", "~> 1.5.6"
+  spec.add_dependency "jwt", ">= 1.5.6"
 end

--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "debugger", "~> 1.6.6"
 
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
-  spec.add_dependency "httparty", "~> 0.15.5"
+  spec.add_dependency "httparty", ">= 0.15.5"
   spec.add_dependency "activesupport", ">= 2.0"
   spec.add_dependency "jwt", ">= 1.5.6"
 end


### PR DESCRIPTION
[This similar request](https://github.com/opentok/OpenTok-Ruby-SDK/pull/183) seems to have stalled.  So here's a PR for the last item