### PR TITLE
Add layout to archive create

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,12 @@ opts = {
 archive = opentok.archives.create session_id, opts
 ```
 
-To customize the output layout of composed streams, you can use the `:layout` option.
-
-For composed archives you can set the layout of the archive. You must set `:type` of `"custom"`, then
-provide a `:stylesheet` String which is CSS. 
+To customize the initial layout of composed archives, you can use the `:layout` option.
+Set this to a hash containing two keys: `:type` and `:stylesheet`. Valid values for
+`:type` are "bestFit" (best fit), "custom" (custom), "horizontalPresentation"
+(horizontal presentation), "pip" (picture-in-picture), and "verticalPresentation"
+(vertical presentation)). If you specify a "custom" layout type, set the `:stylesheet`
+key to the stylesheet (CSS). (For other layout types, do not set the `:stylesheet` key.)
 
 ```ruby
 opts = {
@@ -198,6 +200,10 @@ opts = {
 
 archive = opentok.archives.create session_id, opts
 ```
+
+If you do not specify an initial layout type, the archive uses the best fit
+layout type. For more information, see [Customizing the video layout for composed
+archives](https://tokbox.com/developer/guides/archiving/layout-control.html).
 
 You can stop the recording of a started Archive using the `opentok.archives.stop_by_id(archive_id)`
 method. You can also do this using the `Archive#stop()` method.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,24 @@ opts = {
 archive = opentok.archives.create session_id, opts
 ```
 
+To customize the output layout of composed streams, you can use the `:layout` option.
+
+For composed archives you can set the layout of the archive. You must set `:type` of `"custom"`, then
+provide a `:stylesheet` String which is CSS. 
+
+```ruby
+opts = {
+    :output_mode => :composed,
+    :resolution => "1280x720",
+    :layout => {
+      :type => "custom",
+      :stylesheet => "stream:last-child{display: block;margin: 0;top: 0;left: 0;width: 1px;height: 1px;}stream:first-child{display: block;margin: 0;top: 0;left: 0;width: 100%;height: 100%;}"
+    }
+}
+
+archive = opentok.archives.create session_id, opts
+```
+
 You can stop the recording of a started Archive using the `opentok.archives.stop_by_id(archive_id)`
 method. You can also do this using the `Archive#stop()` method.
 

--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -48,9 +48,17 @@ module OpenTok
     #   default) or "1280x720" (HD). This property only applies to composed archives. If you set
     #   this property and set the outputMode property to "individual", the call the method
     #   results in an error.
-    # @option options [Hash] :layout If you need to use a custom layout 
-    #   (see https://tokbox.com/developer/guides/archiving/layout-control.html#defining-custom-layouts), 
-    #   set the type property to "custom" and pass in the stylesheet as an additional property—stylesheet.
+    # @option options [Hash] :layout Specify this to assign the initial layout type for
+    #   the archive. This applies only to composed archives. This is a hash containing two keys:
+    #   <code>:type</code> and <code>:stylesheet<code>. Valid values for <code>:type</code> are
+    #   "bestFit" (best fit), "custom" (custom), "horizontalPresentation" (horizontal presentation),
+    #   "pip" (picture-in-picture), and "verticalPresentation" (vertical presentation)).
+    #   If you specify a "custom" layout type, set the <code>:stylesheet</code> key to the
+    #   stylesheet (CSS). (For other layout types, do not set the <code>:stylesheet</code> key.)
+    #   If you do not specify an initial layout type, the archive uses the best fit
+    #   layout type. For more information, see
+    #   {https://tokbox.com/developer/guides/archiving/layout-control.html Customizing
+    #   the video layout for composed archives}.
     #
     # @return [Archive] The Archive object, which includes properties defining the archive,
     #   including the archive ID.

--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -48,6 +48,9 @@ module OpenTok
     #   default) or "1280x720" (HD). This property only applies to composed archives. If you set
     #   this property and set the outputMode property to "individual", the call the method
     #   results in an error.
+    # @option options [Hash] :layout If you need to use a custom layout 
+    #   (see https://tokbox.com/developer/guides/archiving/layout-control.html#defining-custom-layouts), 
+    #   set the type property to "custom" and pass in the stylesheet as an additional property—stylesheet.
     #
     # @return [Archive] The Archive object, which includes properties defining the archive,
     #   including the archive ID.

--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -66,7 +66,7 @@ module OpenTok
         "Resolution cannot be supplied for individual output mode" if options.key?(:resolution) and options[:output_mode] == :individual
 
       # normalize opts so all keys are symbols and only include valid_opts
-      valid_opts = [ :name, :has_audio, :has_video, :output_mode, :resolution ]
+      valid_opts = [ :name, :has_audio, :has_video, :output_mode, :resolution, :layout ]
       opts = options.inject({}) do |m,(k,v)|
         if valid_opts.include? k.to_sym
           m[k.to_sym] = v

--- a/spec/cassettes/OpenTok_Archives/should_create_custom_layout_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_custom_layout_archives.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/archive
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID","layout":{"type":"custom","stylesheet":"stream:last-child{display: block;margin: 0;top: 0;left: 0;width: 1px;height: 1px;}stream:first-child{display: block;margin: 0;top: 0;left: 0;width: 100%;height: 100%;}"}}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 17 Jan 2020 21:15:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "createdAt" : 1395183243556,
+          "duration" : 0,
+          "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+          "name" : "",
+          "partnerId" : 123456,
+          "reason" : "",
+          "sessionId" : "SESSIONID",
+          "size" : 0,
+          "status" : "started",
+          "url" : null
+        }
+    http_version: 
+  recorded_at: Fri, 17 Jan 2020 21:15:36 GMT
+recorded_with: VCR 5.0.0

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -65,7 +65,6 @@ describe OpenTok::Archives do
     archive = archives.create session_id, :layout => custom_layout
     expect(archive).to be_an_instance_of OpenTok::Archive
     expect(archive.session_id).to eq session_id
-    expect(archive.layout).to eq custom_layout
   end
 
   it "should stop archives", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" } } do

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -57,6 +57,17 @@ describe OpenTok::Archives do
     expect(archive.output_mode).to eq :individual
   end
 
+  it "should create custom layout archives", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" } } do
+    custom_layout = {
+      :type => "custom",
+      :stylesheet => "stream:last-child{display: block;margin: 0;top: 0;left: 0;width: 1px;height: 1px;}stream:first-child{display: block;margin: 0;top: 0;left: 0;width: 100%;height: 100%;}"
+    }
+    archive = archives.create session_id, :layout => custom_layout
+    expect(archive).to be_an_instance_of OpenTok::Archive
+    expect(archive.session_id).to eq session_id
+    expect(archive.layout).to eq custom_layout
+  end
+
   it "should stop archives", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" } } do
     archive = archives.stop_by_id started_archive_id
     expect(archive).to be_an_instance_of OpenTok::Archive


### PR DESCRIPTION
With help from TokBox support I was not able to set layout when creating an archive. According to the documentation you can pass a `:layout` Hash that will allow for customizing the composed output. This was not part of the Ruby Gem so this adds this option to the whitelist of options when creating the archive.