### PR TITLE
Fix initialization issue because of Set with Rubies 2.5.x

### DIFF
--- a/lib/opentok/constants.rb
+++ b/lib/opentok/constants.rb
@@ -2,6 +2,6 @@ module OpenTok
   API_URL = "https://api.opentok.com"
   TOKEN_SENTINEL = "T1=="
   ROLES = { subscriber: "subscriber", publisher: "publisher", moderator: "moderator" }
-  ARCHIVE_MODES = Set.new([:manual, :always])
+  ARCHIVE_MODES = ::Set.new([:manual, :always])
   AUTH_EXPIRE = 300
 end

--- a/lib/opentok/version.rb
+++ b/lib/opentok/version.rb
@@ -1,4 +1,4 @@
 module OpenTok
   # @private
-  VERSION = '4.0.0'
+  VERSION = '4.0.1'
 end

--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "debugger", "~> 1.6.6"
 
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
-  spec.add_dependency "httparty", ">= 0.15.5"
+  spec.add_dependency "httparty", ">= 0.18.0"
   spec.add_dependency "activesupport", ">= 2.0"
   spec.add_dependency "jwt", ">= 1.5.6"
 end

--- a/spec/cassettes/OpenTok_Archives/calls_layout_on_archive_object.yml
+++ b/spec/cassettes/OpenTok_Archives/calls_layout_on_archive_object.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/changes_the_layout_of_an_archive.yml
+++ b/spec/cassettes/OpenTok_Archives/changes_the_layout_of_an_archive.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_create_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_archives.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_create_audio_only_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_audio_only_archives.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_create_custom_layout_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_custom_layout_archives.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_create_hd_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_hd_archives.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_create_individual_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_individual_archives.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_create_named_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_named_archives.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_delete_an_archive_by_id.yml
+++ b/spec/cassettes/OpenTok_Archives/should_delete_an_archive_by_id.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 204

--- a/spec/cassettes/OpenTok_Archives/should_find_archives_by_id.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_archives_by_id.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_find_archives_with_unknown_properties.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_archives_with_unknown_properties.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_find_expired_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_expired_archives.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_find_paused_archives_by_id.yml
+++ b/spec/cassettes/OpenTok_Archives/should_find_paused_archives_by_id.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/should_stop_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/should_stop_archives.yml
@@ -10,6 +10,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_all_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_all_archives.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_archives_with_an_offset.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_archives_with_an_offset.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_count_number_of_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_count_number_of_archives.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_part_of_the_archives_when_using_offset_and_count.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_part_of_the_archives_when_using_offset_and_count.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_session_archives.yml
+++ b/spec/cassettes/OpenTok_Archives/when_many_archives_are_created/should_return_session_archives.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Broadcasts/calls_layout_on_broadcast_object.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/calls_layout_on_broadcast_object.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Broadcasts/changes_the_layout_of_a_broadcast.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/changes_the_layout_of_a_broadcast.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Broadcasts/fetches_a_hls_broadcast_url.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/fetches_a_hls_broadcast_url.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Broadcasts/finds_a_broadcast.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/finds_a_broadcast.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Broadcasts/starts_a_rtmp_broadcast.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/starts_a_rtmp_broadcast.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Broadcasts/stops_a_broadcast.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/stops_a_broadcast.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Connections/forces_a_connection_to_be_terminated.yml
+++ b/spec/cassettes/OpenTok_Connections/forces_a_connection_to_be_terminated.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
   response:
     status:
       code: 204

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_default_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_default_sessions.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_for_invalid_media_modes.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_for_invalid_media_modes.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_with_a_location_hint.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_with_a_location_hint.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions_with_a_location_hint.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions_with_a_location_hint.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_sessions_with_a_location_hint.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_sessions_with_a_location_hint.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/with_an_addendum_to_the_user_agent_string/should_append_the_addendum_to_the_user_agent_header.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/with_an_addendum_to_the_user_agent_string/should_append_the_addendum_to_the_user_agent_header.yml
@@ -11,6 +11,8 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %> BOOYAH
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Signals/receives_a_valid_response_for_a_connection.yml
+++ b/spec/cassettes/OpenTok_Signals/receives_a_valid_response_for_a_connection.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
   response:
     status:
       code: 204

--- a/spec/cassettes/OpenTok_Signals/receives_a_valid_response_for_all_connections.yml
+++ b/spec/cassettes/OpenTok_Signals/receives_a_valid_response_for_all_connections.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
   response:
     status:
       code: 204

--- a/spec/cassettes/OpenTok_Sip/receives_a_valid_response.yml
+++ b/spec/cassettes/OpenTok_Sip/receives_a_valid_response.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Streams/get_all_streams_information.yml
+++ b/spec/cassettes/OpenTok_Streams/get_all_streams_information.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Streams/get_specific_stream_information.yml
+++ b/spec/cassettes/OpenTok_Streams/get_specific_stream_information.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_Streams/layout_working_on_two_stream_list.yml
+++ b/spec/cassettes/OpenTok_Streams/layout_working_on_two_stream_list.yml
@@ -13,6 +13,8 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
       - application/json
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
   response:
     status:
       code: 200


### PR DESCRIPTION
Because `Set` is required in the parent class, and referenced ambiguously in `constants.rb`, a `::` symbol is required to make its inheritance explicit.

Furthermore, since `httparty` was not locked to a specific version in the gemspec, the latest changes in that gem added two new parameters to a request header, which needed to be added to all the spec cassettes. 