### PR TITLE
Add ability to specify custom timeout length for HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ require "opentok"
 opentok = OpenTok::OpenTok.new api_key, api_secret
 ```
 
+### Initialization Options
+
+You can specify a custom timeout value for HTTP requests when initializing a new `OpenTok::OpenTok`
+object:
+
+```ruby
+require "opentok"
+
+opentok = OpenTok::OpenTok.new api_key, api_secret, :timeout_length => 10
+```
+
+The value for `:timeout_length` is an integer representing the number of seconds to wait for an HTTP
+request to complete. The default is set to 2 seconds.
+
 ## Creating Sessions
 
 To create an OpenTok Session, use the `OpenTok#create_session(properties)` method.

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -12,18 +12,20 @@ module OpenTok
   class Client
     include HTTParty
 
-    open_timeout 2 # Set HTTParty default timeout (open/read) to 2 seconds
-
     # TODO: expose a setting for http debugging for developers
     # debug_output $stdout
 
-    def initialize(api_key, api_secret, api_url, ua_addendum="")
+    attr_accessor :api_key, :api_secret, :api_url, :ua_addendum, :timeout_length
+
+    def initialize(api_key, api_secret, api_url, ua_addendum='', opts={})
       self.class.base_uri api_url
       self.class.headers({
-        "User-Agent" => "OpenTok-Ruby-SDK/#{VERSION}" + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" + (ua_addendum ? " #{ua_addendum}" : "")        
+        "User-Agent" => "OpenTok-Ruby-SDK/#{VERSION}" + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" + (ua_addendum ? " #{ua_addendum}" : "")
       })
       @api_key = api_key
       @api_secret = api_secret
+      @timeout_length = opts[:timeout_length] || 2
+      self.class.open_timeout @timeout_length
     end
 
     def generate_jwt(api_key, api_secret)

--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -69,7 +69,7 @@ module OpenTok
     # @private
     # don't want these to be mutable, may cause bugs related to inconsistency since these values are
     # cached in objects that this can create
-    attr_reader :api_key, :api_secret, :api_url, :ua_addendum
+    attr_reader :api_key, :api_secret, :timeout_length, :api_url, :ua_addendum
 
     ##
     # Create a new OpenTok object.
@@ -79,9 +79,11 @@ module OpenTok
     # @param [String] api_secret Your OpenTok API key.
     # @option opts [Symbol] :api_url Do not set this parameter. It is for internal use by TokBox.
     # @option opts [Symbol] :ua_addendum Do not set this parameter. It is for internal use by TokBox.
+    # @option opts [Symbol] :timeout_length Custom timeout in seconds. If not provided, defaults to 2 seconds.
     def initialize(api_key, api_secret, opts={})
       @api_key = api_key.to_s()
       @api_secret = api_secret
+      @timeout_length = opts[:timeout_length] || 2
       @api_url = opts[:api_url] || API_URL
       @ua_addendum = opts[:ua_addendum]
     end

--- a/spec/opentok/client_spec.rb
+++ b/spec/opentok/client_spec.rb
@@ -1,0 +1,51 @@
+require "opentok/opentok"
+require "opentok/version"
+
+require "spec_helper"
+require "shared/opentok_generates_tokens"
+
+describe OpenTok::Client do
+  before(:each) do
+    now = Time.parse("2017-04-18 20:17:40 +1000")
+    allow(Time).to receive(:now) { now }
+  end
+
+  let(:api_key) { "123456" }
+  let(:api_secret) { "1234567890abcdef1234567890abcdef1234567890" }
+  let(:api_url) { "https://api.opentok.com" }
+
+
+  let(:client) { OpenTok::Client.new api_key, api_secret, api_url }
+  subject { client }
+
+  context "when initialized with no options" do
+    it { should be_an_instance_of OpenTok::Client }
+
+    it "should have an api_key property" do
+      expect(client.api_key).to eq api_key
+    end
+
+    it "should have an api_secret property" do
+      expect(client.api_secret).to eq api_secret
+    end
+
+    it "should be able to access HTTParty open_timeout method" do
+      expect(OpenTok::Client).to respond_to(:open_timeout)
+    end
+
+    it 'should have a default timeout_length property of 2 seconds' do
+      expect(client.timeout_length).to eq 2
+    end
+  end
+
+  context "when initialized with timeout_length custom option" do
+    let(:client) { OpenTok::Client.new api_key, api_secret, api_url, ua_addendum='', :timeout_length => timeout_length }
+    let(:timeout_length) { 10 }
+
+    it { should be_an_instance_of(OpenTok::Client) }
+
+    it "should override timeout_length default with custom integer" do
+      expect(client.timeout_length).to eq 10
+    end
+  end
+end

--- a/spec/opentok/opentok_spec.rb
+++ b/spec/opentok/opentok_spec.rb
@@ -31,6 +31,10 @@ describe OpenTok::OpenTok do
       expect(opentok.api_url).to eq default_api_url
     end
 
+    it "has the default timeout set" do
+      expect(opentok.timeout_length).to eq 2
+    end
+
     include_examples "opentok generates tokens"
 
     describe "#create_session" do
@@ -137,6 +141,17 @@ describe OpenTok::OpenTok do
 
       # TODO: i don't need to run all the tests, just a set that checks for the URL's effect
       # include_examples "generates tokens"
+    end
+
+    context "with a custom timeout_length" do
+      let(:timeout_length) { 10 }
+      let(:opentok) { OpenTok::OpenTok.new api_key, api_secret, :timeout_length => timeout_length }
+
+      it { should be_an_instance_of(OpenTok::OpenTok) }
+
+      it "should have an timeout_length property" do
+        expect(opentok.timeout_length).to eq timeout_length
+      end
     end
 
     context "with an addendum to the user agent string" do


### PR DESCRIPTION
Related to #105 this creates a definable parameter (Integer, num. of seconds) of `timeout_length` that can be provided or it defaults to `2`.

The name `timeout_length` was chosen because `Object#timeout` is already a reserved keyword in Ruby, as its a class method on `Object`.

There was no test suite for `OpenTok::Client` so that was added as well to test the new functionality.