### PR TITLE
Passing custom timeout length to OpenTok::Client constructor

### DIFF
--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -214,7 +214,7 @@ module OpenTok
 
     protected
     def client
-      @client ||= Client.new api_key, api_secret, api_url, ua_addendum
+      @client ||= Client.new api_key, api_secret, api_url, ua_addendum, timeout_length: @timeout_length
     end
 
   end


### PR DESCRIPTION
When creating OpenTok client like this

```
@opentok = ::OpenTok::OpentTok.new api_key, secret_key, timeout_length: 10
```

That custom `timeout_length` setting is not passed into `OpenTok::Client`

```
protected
def client
  @client ||= Client.new api_key, api_secret, api_url, ua_addendum
end
```

And that parameter is not used, instead default 2 [s] value is used.