### PR TITLE
New spec to ensure custom timeout_length is passed through OpenTok::OpenTok#client

### DIFF
--- a/lib/opentok/version.rb
+++ b/lib/opentok/version.rb
@@ -1,4 +1,4 @@
 module OpenTok
   # @private
-  VERSION = '4.1.0'
+  VERSION = '4.1.1'
 end

--- a/spec/opentok/opentok_spec.rb
+++ b/spec/opentok/opentok_spec.rb
@@ -152,6 +152,12 @@ describe OpenTok::OpenTok do
       it "should have an timeout_length property" do
         expect(opentok.timeout_length).to eq timeout_length
       end
+
+      it "should send the custom timeout_length to new instances of OpenTok::Client" do
+        streams = opentok.streams
+
+        expect(streams.instance_variable_get(:@client).timeout_length).to eq timeout_length
+      end
     end
 
     context "with an addendum to the user agent string" do


### PR DESCRIPTION
Related to #214 

Also, increment version to correspond to patch release in `dev` branch in preparation for next release into `master`