### PR TITLE
update archive code comment to conform with api spec

### DIFF
--- a/lib/opentok/archive.rb
+++ b/lib/opentok/archive.rb
@@ -7,7 +7,7 @@ module OpenTok
     #   The time at which the archive was created, in milliseconds since the UNIX epoch.
     #
     # @attr [string] duration
-    #   The duration of the archive, in milliseconds.
+    #   The duration of the archive, in seconds.
     #
     # @attr [string] id
     #   The archive ID.


### PR DESCRIPTION
Fixes #222 

PR aligns code comment on `duration` with [API specification](https://tokbox.com/developer/rest/#retrieve_archive_info)