### PR TITLE
DEVX-5663 Add SIP observeForceMute flag

### DIFF
--- a/lib/opentok/sip.rb
+++ b/lib/opentok/sip.rb
@@ -13,7 +13,8 @@ module OpenTok
     #      "headers" => { "X-KEY1" => "value1",
     #        "X-KEY1" => "value2" },
     #      "secure" => "true",
-    #      "video" => "true"
+    #      "video" => "true",
+    #      "observe_force_mute" => "true"
     #    }
     #    response = opentok.sip.dial(session_id, token, "sip:+15128675309@acme.pstn.example.com;transport=tls", opts)
     # @param [String] session_id The session ID corresponding to the session to which
@@ -41,6 +42,8 @@ module OpenTok
     # client's video is included in the OpenTok stream that is sent to the
     # OpenTok session. The SIP client will receive a single composed video of
     # the published streams in the OpenTok session.
+    # @option opts  [true, false] :observe_force_mute Whether the SIP end point
+    # observes force mute moderation (true) or not (false, the default).
     def dial(session_id, token, sip_uri, opts)
       response = @client.dial(session_id, token, sip_uri, opts)
     end

--- a/lib/opentok/sip.rb
+++ b/lib/opentok/sip.rb
@@ -43,7 +43,8 @@ module OpenTok
     # OpenTok session. The SIP client will receive a single composed video of
     # the published streams in the OpenTok session.
     # @option opts  [true, false] :observe_force_mute Whether the SIP end point
-    # observes force mute moderation (true) or not (false, the default).
+    # observes {https://tokbox.com/developer/guides/moderation/#force_mute force mute moderation}
+    # (true) or not (false, the default).
     def dial(session_id, token, sip_uri, opts)
       response = @client.dial(session_id, token, sip_uri, opts)
     end

--- a/spec/cassettes/OpenTok_Sip/receives_a_valid_response.yml
+++ b/spec/cassettes/OpenTok_Sip/receives_a_valid_response.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.opentok.com/v2/project/123456/dial
     body:
       encoding: UTF-8
-      string: '{"sessionId":"SESSIONID","token":"TOKENID","sip":{"uri":"sip:+15128675309@acme.pstn.example.com;transport=tls","auth":{"username":"bob","password":"abc123"},"secure":"true","video":"true"}}'
+      string: '{"sessionId":"SESSIONID","token":"TOKENID","sip":{"uri":"sip:+15128675309@acme.pstn.example.com;transport=tls","auth":{"username":"bob","password":"abc123"},"secure":"true","video":"true","observeForceMute":"true"}}'
     headers:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>

--- a/spec/opentok/sip_spec.rb
+++ b/spec/opentok/sip_spec.rb
@@ -24,7 +24,8 @@ describe OpenTok::Sip do
     opts = { "auth" => { "username" => sip_username,
                          "password" => sip_password },
              "secure" => "true",
-             "video" => "true"
+             "video" => "true",
+             "observe_force_mute" => "true"
     }
     response = sip.dial(session_id, expiring_token, sip_uri, opts)
     expect(response).not_to be_nil


### PR DESCRIPTION
This PR provides clarity around use of the `observe_force_mute` option when making a SIP call using the `Sip#dial` method.

## Description

Including `'"observeForceMute":"true"` as part of the JSON payload for call to the `/dial` API endpoint indicates whether the SIP end point observes [force mute moderation](https://tokbox.com/developer/guides/moderation/). This property can be included in the payload by adding it as an option in the `opts` hash passed to `Sip#dial` [method](https://github.com/opentok/OpenTok-Ruby-SDK/blob/142ef849cba11715a31b3513e8d87eec376de793/lib/opentok/sip.rb#L38). No changes were required to the implementation of the method, since the method can already accept `observe_force_mute` as a key in the `opts` hash (the method is very lenient with regards to keys that can be included in the hash). 

The only changes were to the code comments in the `Sip#dial` method definition, and to the relevant specs.

## Motivation and Context

Ongoing development to roll out new API features.

## How Has This Been Tested?

Existing spec has been updated to include the option for `observe_force_mute`. Test suite has been run to pass.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

*Note:* not technically a bug-fix, but not technically implementing a new feature either, but clarifies/ highlights the ability to use a new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.