### PR TITLE
feat: add `Listing live streaming broadcasts` support

### DIFF
--- a/lib/opentok/broadcast_list.rb
+++ b/lib/opentok/broadcast_list.rb
@@ -2,7 +2,7 @@ require "opentok/broadcast"
 
 module OpenTok
   # A class for accessing an array of Broadcast objects.
-  class BroadcastList
+  class BroadcastList < Array
     # The total number of broadcasts.
     attr_reader :total
 

--- a/lib/opentok/broadcast_list.rb
+++ b/lib/opentok/broadcast_list.rb
@@ -1,0 +1,14 @@
+require "opentok/broadcast"
+
+module OpenTok
+  # A class for accessing an array of Broadcast objects.
+  class BroadcastList
+    # The total number of broadcasts.
+    attr_reader :total
+
+    def initialize(interface, json)
+      @total = json["count"]
+      super json["items"].map { |item| ::OpenTok::Broadcast.new interface, item }
+    end
+  end
+end

--- a/lib/opentok/broadcasts.rb
+++ b/lib/opentok/broadcasts.rb
@@ -1,6 +1,6 @@
 require "opentok/client"
 require "opentok/broadcast"
-
+require "opentok/broadcast_list"
 
 module OpenTok
   # A class for working with OpenTok live streaming broadcasts.

--- a/lib/opentok/broadcasts.rb
+++ b/lib/opentok/broadcasts.rb
@@ -95,6 +95,25 @@ module OpenTok
       Broadcast.new self, broadcast_json
     end
 
+    # Returns a BroadcastList, which is an array of broadcasts that are completed and in-progress,
+    # for your API key.
+    #
+    # @param [Hash] options  A hash with keys defining which range of broadcasts to retrieve.
+    # @option options [integer] :offset Optional. The index offset of the first broadcast. 0 is offset
+    #   of the most recently started broadcast. 1 is the offset of the broadcast that started prior to
+    #   the most recent broadcast. If you do not specify an offset, 0 is used.
+    # @option options [integer] :count Optional. The number of broadcasts to be returned. The maximum
+    #   number of broadcasts returned is 1000.
+    # @option options [String] :session_id Optional. The session ID that broadcasts belong to.
+    # https://tokbox.com/developer/rest/#list_broadcasts
+    #
+    # @return [BroadcastList] An BroadcastList object, which is an array of Broadcast objects.
+    def all(options = {})
+      raise ArgumentError, "Limit is invalid" unless options[:count].nil? || (0..1000).include?(options[:count])
+
+      broadcast_list_json = @client.list_broadcasts(options[:offset], options[:count], options[:sessionId])
+      BroadcastList.new self, broadcast_list_json
+    end
 
     # Stops an OpenTok broadcast
     #

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -483,6 +483,28 @@ module OpenTok
       raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
     end
 
+    def list_broadcasts(offset, count, session_id)
+      query = Hash.new
+      query[:offset] = offset unless offset.nil?
+      query[:count] = count unless count.nil?
+      query[:sessionId] = session_id unless session_id.nil?
+      response = self.class.get("/v2/project/#{@api_key}/broadcast", {
+        :query => query.empty? ? nil : query,
+        :headers => generate_headers,
+      })
+      case response.code
+      when 200
+        response
+      when 403
+        raise OpenTokAuthenticationError,
+          "Authentication failed while retrieving broadcasts. API Key: #{@api_key}"
+      else
+        raise OpenTokBroadcastError, "The broadcasts could not be retrieved."
+      end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
+    end
+
     def layout_broadcast(broadcast_id, opts)
       opts.extend(HashExtensions)
       response = self.class.put("/v2/project/#{@api_key}/broadcast/#{broadcast_id}/layout", {

--- a/lib/opentok/token_generator.rb
+++ b/lib/opentok/token_generator.rb
@@ -4,6 +4,7 @@ require "opentok/session"
 require "base64"
 require "addressable/uri"
 require "openssl"
+require "active_support"
 require "active_support/time"
 
 module OpenTok

--- a/lib/opentok/version.rb
+++ b/lib/opentok/version.rb
@@ -1,4 +1,4 @@
 module OpenTok
   # @private
-  VERSION = '4.3.0'
+  VERSION = '4.2.0'
 end

--- a/sample/Broadcast/README.md
+++ b/sample/Broadcast/README.md
@@ -172,11 +172,9 @@ You will now see the participant in the broadcast.
 
 Start by visiting the list page at <http://localhost:4567/all>. You will see a table that
 displays all the broadcasts created with your API Key. If there are more than five, the next ones
-can be seen by clicking the "Next →" link. If you click on the name of an archive, your browser
-will start downloading the archive file. If you click the "Delete" link in the end of the row
-for any archive, that archive will be deleted and no longer available. Some basic information like
-when the archive was created, how long it is, and its status is also shown. You should see the
-archives you created in the previous sections here.
+can be seen by clicking the "Next →" link. Some basic information like
+when the broadcast was created, how long it is, and its status is also shown. You should see the
+broadcasts you created in the previous sections here.
 
 We begin to see how this page is created by looking at the route handler for this URL:
 
@@ -199,19 +197,18 @@ We begin to see how this page is created by looking at the route handler for thi
 
 This view is paginated so that we don't potentially show hundreds of rows on the table, which would
 be difficult for the user to navigate. So this code starts by figuring out which page needs to be
-shown, where each page is a set of 5 archives. The `page` number is read from the request's query
+shown, where each page is a set of 5 broadcasts. The `page` number is read from the request's query
 string parameters as a string and then converted into an Integer. The `offset`, which represents how
-many archives are being skipped is always calculated as five times as many pages that are less than
+many broadcasts are being skipped is always calculated as five times as many pages that are less than
 the current page, which is `(page - 1) * 5`. Now there is enough information to ask for a list of
-archives from OpenTok, which we do by calling the `archives.all()` method of the `opentok` instance.
+broadcasts from OpenTok, which we do by calling the `broadcasts.all()` method of the `opentok` instance.
 The parameter is an optional Hash that contains the offset, the count (which is always 5 in this
 view). If we are not at the first page, we can pass the view a string that contains the relative URL
 for the previous page. Similarly, we can also include one for the next page. Now the application
-renders the view using that information and the partial list of archives.
+renders the view using that information and the partial list of broadcasts.
 
-At this point the template file `views/history.erb` handles looping over the array of archives and
-outputting the proper information for each column in the table. It also places a link to the
-download and delete routes around the archive's name and its delete button, respectively.
+At this point the template file `views/all.erb` handles looping over the array of broadcasts and
+outputting the proper information for each column in the table.
 
 ### Changing the layout classes for streams
 

--- a/sample/Broadcast/README.md
+++ b/sample/Broadcast/README.md
@@ -168,6 +168,51 @@ You will now see the participant in the broadcast.
   end
 ```
 
+### All broadcasts
+
+Start by visiting the list page at <http://localhost:4567/all>. You will see a table that
+displays all the broadcasts created with your API Key. If there are more than five, the next ones
+can be seen by clicking the "Next →" link. If you click on the name of an archive, your browser
+will start downloading the archive file. If you click the "Delete" link in the end of the row
+for any archive, that archive will be deleted and no longer available. Some basic information like
+when the archive was created, how long it is, and its status is also shown. You should see the
+archives you created in the previous sections here.
+
+We begin to see how this page is created by looking at the route handler for this URL:
+
+```ruby
+  get '/all' do
+    page = (params[:page] || "1").to_i
+    offset = (page - 1) * 5
+    broadcasts = settings.opentok.broadcasts.all(:offset => offset, :count => 5)
+
+    show_previous = page > 1 ? '/all?page=' + (page-1).to_s : nil
+    show_next = broadcasts.total > (offset + 5) ? '/all?page=' + (page+1).to_s : nil
+
+    erb :all, :locals => {
+      :broadcasts => broadcasts,
+      :show_previous => show_previous,
+      :show_next => show_next
+    }
+  end
+```
+
+This view is paginated so that we don't potentially show hundreds of rows on the table, which would
+be difficult for the user to navigate. So this code starts by figuring out which page needs to be
+shown, where each page is a set of 5 archives. The `page` number is read from the request's query
+string parameters as a string and then converted into an Integer. The `offset`, which represents how
+many archives are being skipped is always calculated as five times as many pages that are less than
+the current page, which is `(page - 1) * 5`. Now there is enough information to ask for a list of
+archives from OpenTok, which we do by calling the `archives.all()` method of the `opentok` instance.
+The parameter is an optional Hash that contains the offset, the count (which is always 5 in this
+view). If we are not at the first page, we can pass the view a string that contains the relative URL
+for the previous page. Similarly, we can also include one for the next page. Now the application
+renders the view using that information and the partial list of archives.
+
+At this point the template file `views/history.erb` handles looping over the array of archives and
+outputting the proper information for each column in the table. It also places a link to the
+download and delete routes around the archive's name and its delete button, respectively.
+
 ### Changing the layout classes for streams
 
 In the host page, if you click on either the host or a participant video, that video gets

--- a/sample/Broadcast/broadcast_sample.rb
+++ b/sample/Broadcast/broadcast_sample.rb
@@ -46,6 +46,21 @@ class BroadcastSample < Sinatra::Base
     }
   end
 
+  get '/all' do
+    page = (params[:page] || "1").to_i
+    offset = (page - 1) * 5
+    broadcasts = settings.opentok.broadcasts.all(:offset => offset, :count => 5)
+
+    show_previous = page > 1 ? '/all?page=' + (page-1).to_s : nil
+    show_next = broadcasts.total > (offset + 5) ? '/all?page=' + (page+1).to_s : nil
+
+    erb :all, :locals => {
+      :broadcasts => broadcasts,
+      :show_previous => show_previous,
+      :show_next => show_next
+    }
+  end
+
   post '/start' do
     opts = {
         :maxDuration => params.key?("maxDuration") ? params[:maxDuration] : 7200,

--- a/sample/Broadcast/views/all.erb
+++ b/sample/Broadcast/views/all.erb
@@ -1,0 +1,46 @@
+  <div class="container bump-me">
+
+    <div class="body-content">
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Broadcasts List</h3>
+        </div>
+        <div class="panel-body">
+          <% if broadcasts.count > 0 %>
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Created</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% for item in broadcasts %>
+
+              <tr data-item-id="<%= item.id %>">
+                <td><%= Time.at(item.created_at/1000).strftime("%B %e, %Y at %I:%M %p") %></td>
+                <td><%= item.status %></td>
+              </tr>
+
+              <% end %>
+            </tbody>
+          </table>
+          <% else %>
+          <p>
+            There are no broadcasts currently. Try making one in the <a href="/host">host view</a>.
+          </p>
+          <% end %>
+        </div>
+        <div class="panel-footer">
+          <% if show_previous %>
+            <a href="<%= show_previous %>" class="pull-left">&larr; Previous</a>
+          <% end %>
+          &nbsp;
+          <% if show_next %>
+            <a href="<%= show_next %>" class="pull-right">Next &rarr;</a>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/sample/Broadcast/views/index.erb
+++ b/sample/Broadcast/views/index.erb
@@ -25,6 +25,21 @@
           </div>
 
         </div>
+        <div class="col-lg-6 col-offset-1">
+
+          <div class="panel panel-default">
+            <div class="panel-heading">List of Broadcasts</div>
+            <div class="panel-body">
+              <p>
+                Click through to List of Broadcasts to see examples of using the
+                Broadcasting REST API to list broadcasts showing status (started,
+                stopped, available) and created at timestamp.
+              </p>
+            </div>
+            <div class="panel-footer">
+              <a class="btn btn-success" href="all">List of Broadcasts</a>
+            </div>
+          </div>
 
     </div>
 

--- a/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_all_broadcasts.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_all_broadcasts.yml
@@ -1,0 +1,192 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/broadcast
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 21 Jan 2022 12:05:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 6,
+          "items" : [ {
+            "id" : "ef546c5a-4fd7-4e59-ab3d-f1cfb4148d1d",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395187930000,
+            "updatedAt": 1395187930000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F5350f06f-0166-402e-bc27-09ba54948512.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream1",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream1",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "f6e7ee58-d6cf-4a59-896b-6d56b158ec71",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395187910000,
+            "updatedAt": 1395187910000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F5350f06f-0166-402e-bc27-09ba54948512.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream2",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream2",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "ef546c5a-4fd7-4e59-ab3d-f1cfb4148d1d",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395187836000,
+            "updatedAt": 1395187836000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2Ff6e7ee58-d6cf-4a59-896b-6d56b158ec71.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream3",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream3",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395183243000,
+            "updatedAt": 1395183243000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F30b3ebf1-ba36-4f5b-8def-6f70d9986fe9.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream4",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream4",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "b8f64de1-e218-4091-9544-4cbf369fc238",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1394396753000,
+            "updatedAt": 1394396753000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2Fb8f64de1-e218-4091-9544-4cbf369fc238.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream5",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream5",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "832641bf-5dbf-41a1-ad94-fea213e59a92",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1394321113000,
+            "updatedAt": 1394321113000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F832641bf-5dbf-41a1-ad94-fea213e59a92.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream6",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream6",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          } ]
+        }
+    http_version:
+  recorded_at: Fri, 21 Jan 2022 12:05:21 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_broadcasts_with_an_offset.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_broadcasts_with_an_offset.yml
@@ -1,0 +1,117 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/broadcast?offset=3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 21 Jan 2022 12:05:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 3,
+          "items" : [ {
+            "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395183243000,
+            "updatedAt": 1395183243000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F30b3ebf1-ba36-4f5b-8def-6f70d9986fe9.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream4",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream4",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "b8f64de1-e218-4091-9544-4cbf369fc238",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1394396753000,
+            "updatedAt": 1394396753000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2Fb8f64de1-e218-4091-9544-4cbf369fc238.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream5",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream5",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "832641bf-5dbf-41a1-ad94-fea213e59a92",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1394321113000,
+            "updatedAt": 1394321113000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F832641bf-5dbf-41a1-ad94-fea213e59a92.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream6",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream6",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          } ]
+        }
+    http_version:
+  recorded_at: Fri, 21 Jan 2022 12:05:21 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_count_number_of_broadcasts.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_count_number_of_broadcasts.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/broadcast?count=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 21 Jan 2022 12:05:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 2,
+          "items" : [ {
+            "id" : "ef546c5a-4fd7-4e59-ab3d-f1cfb4148d1d",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395187930000,
+            "updatedAt": 1395187930000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F5350f06f-0166-402e-bc27-09ba54948512.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream1",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream1",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "f6e7ee58-d6cf-4a59-896b-6d56b158ec71",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395187910000,
+            "updatedAt": 1395187910000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F5350f06f-0166-402e-bc27-09ba54948512.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream2",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream2",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          } ]
+        }
+    http_version:
+  recorded_at: Fri, 21 Jan 2022 12:05:21 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_part_of_the_broadcasts_when_using_offset_and_count.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_part_of_the_broadcasts_when_using_offset_and_count.yml
@@ -1,0 +1,142 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/broadcast?count=4&offset=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 21 Jan 2022 12:05:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 4,
+          "items" : [ {
+            "id" : "ef546c5a-4fd7-4e59-ab3d-f1cfb4148d1d",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395187836000,
+            "updatedAt": 1395187836000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2Ff6e7ee58-d6cf-4a59-896b-6d56b158ec71.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream3",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream3",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395183243000,
+            "updatedAt": 1395183243000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F30b3ebf1-ba36-4f5b-8def-6f70d9986fe9.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream4",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream4",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "b8f64de1-e218-4091-9544-4cbf369fc238",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1394396753000,
+            "updatedAt": 1394396753000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2Fb8f64de1-e218-4091-9544-4cbf369fc238.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream5",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream5",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "832641bf-5dbf-41a1-ad94-fea213e59a92",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1394321113000,
+            "updatedAt": 1394321113000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F832641bf-5dbf-41a1-ad94-fea213e59a92.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream6",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream6",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          } ]
+        }
+    http_version:
+  recorded_at: Fri, 21 Jan 2022 12:05:21 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_session_broadcasts.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/for_many_broadcasts/should_return_session_broadcasts.yml
@@ -1,0 +1,117 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/broadcast?sessionId=SESSIONID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 21 Jan 2022 12:05:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 3,
+          "items" : [ {
+            "id" : "ef546c5a-4fd7-4e59-ab3d-f1cfb4148d1d",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395187930000,
+            "updatedAt": 1395187930000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F5350f06f-0166-402e-bc27-09ba54948512.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream1",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream1",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "f6e7ee58-d6cf-4a59-896b-6d56b158ec71",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395187910000,
+            "updatedAt": 1395187910000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2F5350f06f-0166-402e-bc27-09ba54948512.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream2",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream2",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          }, {
+            "id" : "ef546c5a-4fd7-4e59-ab3d-f1cfb4148d1d",
+            "sessionId" : "SESSIONID",
+            "projectId": 123456,
+            "createdAt" : 1395187836000,
+            "updatedAt": 1395187836000,
+            "resolution": "640x480",
+            "broadcastUrls": {
+              "hls" : "http://tokbox.com.broadcast2.s3.amazonaws.com/123456%2Ff6e7ee58-d6cf-4a59-896b-6d56b158ec71.m3u8",
+              "rtmp": {
+                "foo": {
+                  "serverUrl": "rtmps://myfooserver/myfooapp",
+                  "streamName": "myfoostream3",
+                  "status": "started"
+                },
+                "bar": {
+                  "serverUrl": "rtmp://mybarserver/mybarapp",
+                  "streamName": "mybarstream3",
+                  "status": "live"
+                }
+              }
+            },
+            "status": "started",
+            "streamMode" : "manual",
+            "streams" : []
+          } ]
+        }
+    http_version:
+  recorded_at: Fri, 21 Jan 2022 12:05:21 GMT
+recorded_with: VCR 6.0.0

--- a/spec/opentok/broadcasts_spec.rb
+++ b/spec/opentok/broadcasts_spec.rb
@@ -234,4 +234,40 @@ describe OpenTok::Broadcasts do
     expect(response.code).to eq(204)
   end
 
+  context "for many broadcasts" do
+    it "should return all broadcasts", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+      broadcast_list = broadcasts.all
+      expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
+      expect(broadcast_list.total).to eq 6
+      expect(broadcast_list.count).to eq 6
+    end
+
+    it "should return broadcasts with an offset", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+      broadcast_list = broadcasts.all :offset => 3
+      expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
+      expect(broadcast_list.total).to eq 3
+      expect(broadcast_list.count).to eq 3
+    end
+
+    it "should return count number of broadcasts", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+      broadcast_list = broadcasts.all :count => 2
+      expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
+      expect(broadcast_list.count).to eq 2
+      expect(broadcast_list.count).to eq 2
+    end
+
+    it "should return part of the broadcasts when using offset and count", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+      broadcast_list = broadcasts.all :count => 4, :offset => 2
+      expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
+      expect(broadcast_list.count).to eq 4
+      expect(broadcast_list.count).to eq 4
+    end
+
+    it "should return session broadcasts", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+      broadcast_list = broadcasts.all :sessionId => session_id
+      expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
+      expect(broadcast_list.total).to eq 3
+      expect(broadcast_list.count).to eq 3
+    end
+  end
 end

--- a/spec/opentok/broadcasts_spec.rb
+++ b/spec/opentok/broadcasts_spec.rb
@@ -236,35 +236,35 @@ describe OpenTok::Broadcasts do
 
   context "for many broadcasts" do
     it "should return all broadcasts", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
-      broadcast_list = broadcasts.all
+      broadcast_list = broadcast.all
       expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
       expect(broadcast_list.total).to eq 6
       expect(broadcast_list.count).to eq 6
     end
 
     it "should return broadcasts with an offset", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
-      broadcast_list = broadcasts.all :offset => 3
+      broadcast_list = broadcast.all :offset => 3
       expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
       expect(broadcast_list.total).to eq 3
       expect(broadcast_list.count).to eq 3
     end
 
     it "should return count number of broadcasts", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
-      broadcast_list = broadcasts.all :count => 2
+      broadcast_list = broadcast.all :count => 2
       expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
       expect(broadcast_list.count).to eq 2
       expect(broadcast_list.count).to eq 2
     end
 
     it "should return part of the broadcasts when using offset and count", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
-      broadcast_list = broadcasts.all :count => 4, :offset => 2
+      broadcast_list = broadcast.all :count => 4, :offset => 2
       expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
       expect(broadcast_list.count).to eq 4
       expect(broadcast_list.count).to eq 4
     end
 
     it "should return session broadcasts", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
-      broadcast_list = broadcasts.all :sessionId => session_id
+      broadcast_list = broadcast.all :sessionId => session_id
       expect(broadcast_list).to be_an_instance_of OpenTok::BroadcastList
       expect(broadcast_list.total).to eq 3
       expect(broadcast_list.count).to eq 3


### PR DESCRIPTION
This PR adds a missing client implementation for [ Listing live streaming broadcasts](https://tokbox.com/developer/rest/#list_broadcasts) support. 
The solution is heavily based on the `List archives` codebase.

The added specs are disabled right now, since I don't have any test credentials to generate the test mocks.
Any insights or feedbacks on making this Pull Request are welcomed.