### PR TITLE
DEVX-5446  Making amendments to force mute feature to disable mute state

### DIFF
--- a/lib/opentok/streams.rb
+++ b/lib/opentok/streams.rb
@@ -84,13 +84,18 @@ module OpenTok
       response = @client.force_mute_stream(session_id, stream_id)
     end
 
-    # Force all streams connected to an OpenTok session, and all future streams
-    # connecting to that session, to mute themselves.
+    # Force all streams connected to an OpenTok session (except for an optional list of streams),
+    # to mute published audio.
+    # 
+    # In addition to existing streams, any streams that are published after the call to
+    # this method are published with audio muted. You can remove the mute state of a session
+    # by calling the disable_force_mute() method.
     #
-    # @param [String] session_id The session ID of the OpenTok session.
+    # @param [String] session_id The session ID.
     # @param [Hash] opts An optional hash defining options for muting action. For example:
     # @option opts [Array] :excluded_streams The stream IDs for streams that should not be muted.
     # This is an optional property. If you omit this property, all streams in the session will be muted.
+    #
     # @example
     # {
     #   "excluded_streams" => [
@@ -104,11 +109,15 @@ module OpenTok
       response = @client.force_mute_session(session_id, opts)
     end
 
-    # Disables the 'mute state' of a session. In other words, if a session has been
-    # set to mute future streams (e.g. by calling force_mute_all), calling this method
-    # sets the session to not mute future streams.
+    # Disables the active mute state of the session. After you call this method, new streams
+    # published to the session will no longer have audio muted.
     #
-    # @param [String] session_id The session ID of the OpenTok session.
+    # After you call the force_mute_all() method, any streams published after
+    # the call are published with audio muted. Call the disable_force_mute() method
+    # to remove the mute state of a session, so that new published streams are not
+    # automatically muted.
+    #
+    # @param [String] session_id The session ID.
     #
     def disable_force_mute(session_id)
       opts = {'active' => 'false'}

--- a/lib/opentok/streams.rb
+++ b/lib/opentok/streams.rb
@@ -84,24 +84,34 @@ module OpenTok
       response = @client.force_mute_stream(session_id, stream_id)
     end
 
-    # Force all streams connected to an OpenTok session to mute themselves.
+    # Force all streams connected to an OpenTok session, and all future streams
+    # connecting to that session, to mute themselves.
     #
     # @param [String] session_id The session ID of the OpenTok session.
     # @param [Hash] opts An optional hash defining options for muting action. For example:
-    # @option opts [true, false] :active Whether streams published after this call, in
-    # addition to the current streams in the session, should be muted (true) or not (false).
     # @option opts [Array] :excluded_streams The stream IDs for streams that should not be muted.
     # This is an optional property. If you omit this property, all streams in the session will be muted.
     # @example
     # {
-    #   "active": true,
-    #   "excluded_streams": [
+    #   "excluded_streams" => [
     #     "excludedStreamId1",
     #     "excludedStreamId2"
     #   ]
     # }
     #
     def force_mute_all(session_id, opts = {})
+      opts['active'] = 'true'
+      response = @client.force_mute_session(session_id, opts)
+    end
+
+    # Disables the 'mute state' of a session. In other words, if a session has been
+    # set to mute future streams (e.g. by calling force_mute_all), calling this method
+    # sets the session to not mute future streams.
+    #
+    # @param [String] session_id The session ID of the OpenTok session.
+    #
+    def disable_force_mute(session_id)
+      opts = {'active' => 'false'}
       response = @client.force_mute_session(session_id, opts)
     end
 

--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
   spec.add_dependency "httparty", ">= 0.18.0"
-  spec.add_dependency "activesupport", ">= 2.0"
+  spec.add_dependency "activesupport", "~> 6"
   spec.add_dependency "jwt", ">= 1.5.6"
 end

--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
   spec.add_dependency "httparty", ">= 0.18.0"
-  spec.add_dependency "activesupport", "~> 6"
+  spec.add_dependency "activesupport", ">= 2.0"
   spec.add_dependency "jwt", ">= 1.5.6"
 end

--- a/spec/cassettes/OpenTok_Streams/disables_the_mute_state_of_a_session.yml
+++ b/spec/cassettes/OpenTok_Streams/disables_the_mute_state_of_a_session.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.opentok.com/v2/project/123456/session/SESSIONID/mute
     body:
       encoding: UTF-8
-      string: "{}"
+      string: '{"active":"false"}'
     headers:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>
@@ -25,9 +25,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 29 Oct 2021 11:48:19 GMT
-      Content-Type:
-      - application/json
+      - Thu, 13 Jan 2022 15:37:24 GMT
       Content-Length:
       - '0'
       Connection:

--- a/spec/cassettes/OpenTok_Streams/forces_all_current_and_future_streams_in_a_session_to_be_muted.yml
+++ b/spec/cassettes/OpenTok_Streams/forces_all_current_and_future_streams_in_a_session_to_be_muted.yml
@@ -25,13 +25,13 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 29 Oct 2021 11:57:18 GMT
+      - Fri, 29 Oct 2021 11:48:19 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '0'
       Connection:
-      - keep-alive
+      - close
     body:
       encoding: UTF-8
       string: ''

--- a/spec/cassettes/OpenTok_Streams/forces_all_current_and_future_streams_in_a_session_to_be_muted_except_for_the_specified_excluded_streams.yml
+++ b/spec/cassettes/OpenTok_Streams/forces_all_current_and_future_streams_in_a_session_to_be_muted_except_for_the_specified_excluded_streams.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.opentok.com/v2/project/123456/session/SESSIONID/mute
     body:
       encoding: UTF-8
-      string: '{"excludedStreams":["b1963d15-537f-459a-be89-e00fc310b82b"]}'
+      string: '{"excludedStreams":["b1963d15-537f-459a-be89-e00fc310b82b"],"active":"true"}'
     headers:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>

--- a/spec/opentok/streams_spec.rb
+++ b/spec/opentok/streams_spec.rb
@@ -78,18 +78,18 @@ describe OpenTok::Streams do
     expect(response.code).to eq(200)
   end
 
-  it "forces all streams in a session to be muted", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+  it "forces all current and future streams in a session to be muted", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
     response = streams.force_mute_all(session_id)
     expect(response.code).to eq(200)
   end
 
-  it "forces all current streams in a session and future streams joining the session to be muted", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
-    response = streams.force_mute_all(session_id, { "active" => "true" })
+  it "forces all current and future streams in a session to be muted except for the specified excluded streams", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    response = streams.force_mute_all(session_id, { "excludedStreams" => ["b1963d15-537f-459a-be89-e00fc310b82b"] })
     expect(response.code).to eq(200)
   end
 
-  it "forces all current streams in a session to be muted except for the specified excluded streams", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
-    response = streams.force_mute_all(session_id, { "excludedStreams" => ["b1963d15-537f-459a-be89-e00fc310b82b"] })
+  it "disables the 'mute state' of a session", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    response = streams.disable_force_mute(session_id)
     expect(response.code).to eq(200)
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates the force mute feature, to set the `force_mute_all` method to have `active` set to `true` by default (in order to mute all future streams) and to add an additional method `disable_force_mute`, which sets `active` to `false` in order to disable the mute state of the session (so that future streams are not automatically muted).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It implements a feature in the SDK which has already been added to the API. The main elements of the feature were added in #233, but this PR makes amendments to the feature to bring it in line with the actual API (some aspects of the previous implementation were erroneous due to and inaccuracies in the documentation).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
