### PR TITLE
DEVX-5914 Add 1080p for Archive and Broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenTok Ruby SDK
 
 ![Coverage Status](https://github.com/opentok/OpenTok-Ruby-SDK/workflows/CI/badge.svg)
-[![codecov](https://codecov.io/gh/opentok/OpenTok-Ruby-SDK/branch/master/graph/badge.svg)](https://codecov.io/gh/opentok/opentok-ruby-sdk) 
+[![codecov](https://codecov.io/gh/opentok/OpenTok-Ruby-SDK/branch/master/graph/badge.svg)](https://codecov.io/gh/opentok/opentok-ruby-sdk)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 <img src="https://assets.tokbox.com/img/vonage/Vonage_VideoAPI_black.svg" height="48px" alt="Tokbox is now known as Vonage" />
@@ -185,8 +185,7 @@ archive = opentok.archives.create session_id :output_mode => :individual
 The `:output_mode => :composed` setting (the default) causes all streams in the archive to be
 recorded to a single (composed) file.
 
-For composed archives you can set the resolution of the archive, either "640x480" (SD, the default)
-or "1280x720" (HD). The `resolution` parameter is optional and could be included in the options
+For composed archives you can set the resolution of the archive, either "640x480" (SD landscape, the default), "1280x720" (HD landscape), "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920" (FHD portrait).. The `resolution` parameter is optional and could be included in the options
 hash (second argument) of the `opentok.archives.create()` method.
 
 ```ruby

--- a/lib/opentok/archive.rb
+++ b/lib/opentok/archive.rb
@@ -34,7 +34,9 @@ module OpenTok
     #   reason the archive stopped (such as "maximum duration exceeded") or failed.
     #
     # @attr [string] resolution
-    #   The resolution of the archive (either "640x480", "1280x720", "480x640", or "720x1280").
+    #   The resolution of the archive, either "640x480" (SD landscape, the default), "1280x720" (HD landscape),
+    #  "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920" (FHD portrait).
+    #   You may want to use a portrait aspect ratio for archives that include video streams from mobile devices (which often use the portrait aspect ratio).
     #   This property is only set for composed archives.
     #
     # @attr [string] session_id

--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -44,15 +44,16 @@ module OpenTok
     #     (<code>:individual</code>). For more information on archiving and the archive file
     #     formats, see the {https://tokbox.com/opentok/tutorials/archiving OpenTok archiving}
     #     programming guide.
-    # @option options [String] :resolution The resolution of the archive, either "640x480" (SD, the
-    #   default) or "1280x720" (HD). This property only applies to composed archives. If you set
-    #   this property and set the outputMode property to "individual", the call the method
-    #   results in an error.
+    # @option options [String] :resolution The resolution of the archive, either "640x480" (SD landscape,
+    #  the default), "1280x720" (HD landscape), "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280"
+    #  (HD portrait), or "1080x1920" (FHD portrait). This property only applies to composed archives. If you set
+    #  this property and set the outputMode property to "individual", a call to the method
+    #  results in an error.
     # @option options [String] :streamMode (Optional) Whether streams included in the archive are selected
     #   automatically ("auto", the default) or manually ("manual"). When streams are selected automatically ("auto"),
     #   all streams in the session can be included in the archive. When streams are selected manually ("manual"),
     #   you specify streams to be included based on calls to the {Archives#add_stream} method. You can specify whether a
-    #   stream's audio, video, or both are included in the archive. 
+    #   stream's audio, video, or both are included in the archive.
     #   In composed archives, in both automatic and manual modes, the archive composer includes streams based
     #   on {https://tokbox.com/developer/guides/archive-broadcast-layout/#stream-prioritization-rules stream prioritization rules}.
     #   Important: this feature is currently available in the Standard environment only.

--- a/lib/opentok/broadcast.rb
+++ b/lib/opentok/broadcast.rb
@@ -20,7 +20,10 @@ module OpenTok
   #   For this start method, this timestamp matches the createdAt timestamp.
   #
   # @attr [string] resolution
-  #   The resolution of the broadcast: either "640x480" (SD, the default) or "1280x720" (HD). This property is optional.
+  #   The resolution of the broadcast: either "640x480" (SD landscape, the default), "1280x720" (HD landscape),
+  #   "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920" (FHD portrait).
+  #   You may want to use a portrait aspect ratio for broadcasts that include video streams from mobile devices (which often use the portrait aspect ratio).
+  #   This property is optional.
   #
   # @attr [string] streamMode
   #   Whether streams included in the broadcast are selected automatically ("auto", the default) or manually ("manual").

--- a/lib/opentok/broadcasts.rb
+++ b/lib/opentok/broadcasts.rb
@@ -75,7 +75,9 @@ module OpenTok
     #  Broadcasts#find method.
     #
     # @option options [string] resolution
-    #   The resolution of the broadcast: either "640x480" (SD, the default) or "1280x720" (HD).
+    #   The resolution of the broadcast: either "640x480" (SD landscape, the default), "1280x720" (HD landscape),
+    #   "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920"
+    #   (FHD portrait).
     #
     # @option options [String] :streamMode (Optional) Whether streams included in the broadcast are selected
     #   automatically ("auto", the default) or manually ("manual"). When streams are selected automatically ("auto"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Updates code comments for the `resolution` property when creating new Archives and Broadcasts to add options for `1920x1080` and `1080x1920`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To keep the code comments in line with the actual resolution options specified in the documentation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No testing required. Code comment updates only.
