### PR TITLE
DEVX-6487: Adding support for multiple archives and records feature

### DIFF
--- a/lib/opentok/archive.rb
+++ b/lib/opentok/archive.rb
@@ -70,12 +70,13 @@ module OpenTok
     #   set to null. The download URL is obfuscated, and the file is only available from the URL for
     #   10 minutes. To generate a new URL, call the Archive.listArchives() or OpenTok.getArchive() method.
   class Archive
-
+    attr_reader :multi_archive_tag
     # @private
     def initialize(interface, json)
       @interface = interface
       # TODO: validate json fits schema
       @json = json
+      @multi_archive_tag = @json['multiArchiveTag']
     end
 
     # A JSON-encoded string representation of the archive.

--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -39,6 +39,13 @@ module OpenTok
     #   (a video track is included). If you set both  <code>has_audio</code> and
     #   <code>has_video</code> to <code>false</code>, the call to the <code>create()</code>
     #   method results in an error.
+    # @option options [String] :multiArchiveTag (Optional) Set this to support recording multiple archives for the same session simultaneously. 
+    #    Set this to a unique string for each simultaneous archive of an ongoing session. You must also set this option when manually starting an archive 
+    #    that is {https://tokbox.com/developer/guides/archiving/#automatic automatically archived}. Note that the `multiArchiveTag` value is not included
+    #    in the response for the methods to {https://tokbox.com/developer/rest/#listing_archives list archives} and 
+    #    {https://tokbox.com/developer/rest/#retrieve_archive_info retrieve archive information}. If you do not specify a unique `multiArchiveTag`, 
+    #    you can only record one archive at a time for a given session. 
+    #    {https://tokbox.com/developer/guides/archiving/#simultaneous-archives See Simultaneous archives}.
     # @option options [String] :output_mode Whether all streams in the archive are recorded
     #     to a single file (<code>:composed</code>, the default) or to individual files
     #     (<code>:individual</code>). For more information on archiving and the archive file

--- a/lib/opentok/broadcast.rb
+++ b/lib/opentok/broadcast.rb
@@ -43,12 +43,13 @@ module OpenTok
   #     * "offline" --     The OpenTok platform could not connect to the remote RTMP server. This is due to an unreachable server or an error in the RTMP handshake. Causes include rejected RTMP connections, non-existing RTMP applications, rejected stream names, authentication errors, etc. Check that the server is online, and that you have provided the correct server URL and stream name.
   #     * "error" --       There is an error in the OpenTok platform.
   class Broadcast
-
+    attr_reader :multi_broadcast_tag
     # @private
     def initialize(interface, json)
       @interface = interface
       # TODO: validate json fits schema
       @json = json
+      @multi_broadcast_tag = @json['multiBroadcastTag']
     end
 
     # A JSON-encoded string representation of the broadcast.

--- a/lib/opentok/broadcasts.rb
+++ b/lib/opentok/broadcasts.rb
@@ -38,7 +38,7 @@ module OpenTok
     #   layout type.
     #
     # @option options [String] :multiBroadcastTag (Optional) Set this to support multiple broadcasts for the same session simultaneously. 
-    #   Set this to a unique string for each simultaneous broadcast of an ongoing session. Note that the multiBroadcastTag value is not included 
+    #   Set this to a unique string for each simultaneous broadcast of an ongoing session. Note that the `multiBroadcastTag` value is *not* included 
     #   in the response for the methods to {https://tokbox.com/developer/rest/#list_broadcasts list live streaming broadcasts} and 
     #   {https://tokbox.com/developer/rest/#get_info_broadcast get information about a live streaming broadcast}. 
     #   {https://tokbox.com/developer/guides/broadcast/live-streaming#simultaneous-broadcasts See Simultaneous broadcasts}.

--- a/lib/opentok/broadcasts.rb
+++ b/lib/opentok/broadcasts.rb
@@ -37,6 +37,12 @@ module OpenTok
     #   If you do not specify an initial layout type, the broadcast uses the best fit
     #   layout type.
     #
+    # @option options [String] :multiBroadcastTag (Optional) Set this to support multiple broadcasts for the same session simultaneously. 
+    #   Set this to a unique string for each simultaneous broadcast of an ongoing session. Note that the multiBroadcastTag value is not included 
+    #   in the response for the methods to {https://tokbox.com/developer/rest/#list_broadcasts list live streaming broadcasts} and 
+    #   {https://tokbox.com/developer/rest/#get_info_broadcast get information about a live streaming broadcast}. 
+    #   {https://tokbox.com/developer/guides/broadcast/live-streaming#simultaneous-broadcasts See Simultaneous broadcasts}.
+    #
     # @option options [int] maxDuration
     #   The maximum duration for the broadcast, in seconds. The broadcast will automatically stop when
     #   the maximum duration is reached. You can set the maximum duration to a value from 60 (60 seconds) to 36000 (10 hours).

--- a/spec/cassettes/OpenTok_Archives/should_create_an_archives_with_a_matching_multi_archive_tag_tag_value_when_multiArchiveTag_is_specified.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_an_archives_with_a_matching_multi_archive_tag_tag_value_when_multiArchiveTag_is_specified.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/archive
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID"}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Oct 2022 10:19:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "createdAt" : 1395183243556,
+          "duration" : 0,
+          "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+          "name" : "",
+          "partnerId" : 123456,
+          "reason" : "",
+          "sessionId" : "SESSIONID",
+          "size" : 0,
+          "status" : "started",
+          "url" : null,
+          "multiArchiveTag":"archive-1"
+        }
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_Archives/should_create_an_archives_with_a_multi_archive_tag_tag_value_of_nil_when_multiArchiveTag_is_not_specified.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_an_archives_with_a_multi_archive_tag_tag_value_of_nil_when_multiArchiveTag_is_not_specified.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/archive
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID"}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Oct 2022 10:19:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "createdAt" : 1395183243556,
+          "duration" : 0,
+          "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+          "name" : "",
+          "partnerId" : 123456,
+          "reason" : "",
+          "sessionId" : "SESSIONID",
+          "size" : 0,
+          "status" : "started",
+          "url" : null
+        }
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_Archives/should_create_an_archives_with_a_specified_multiArchiveTag.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_an_archives_with_a_specified_multiArchiveTag.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/archive
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID"}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 07 Sep 2022 14:23:34 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "createdAt" : 1395183243556,
+          "duration" : 0,
+          "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+          "name" : "",
+          "partnerId" : 123456,
+          "reason" : "",
+          "sessionId" : "SESSIONID",
+          "size" : 0,
+          "status" : "started",
+          "url" : null,
+          "multiArchiveTag":"archive-1"
+        }
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_Broadcasts/starts_a_broadcast_with_a_matching_multi_broadcast_tag_value_when_multiBroadcastTag_is_specified.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/starts_a_broadcast_with_a_matching_multi_broadcast_tag_value_when_multiBroadcastTag_is_specified.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/broadcast
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID","outputs":{"hls":{}},"multiBroadcastTag":"broadcast-1"}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Oct 2022 11:11:31 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+        "id":"BROADCASTID",
+        "sessionId":"SESSIONID",
+        "projectId":123456,
+        "createdAt":1538086900154,
+        "broadcastUrls":
+                {
+                "hls":"https://cdn-broadcast001-pdx.tokbox.com/14787/14787_b930bf08-1c9f-4c55-ab04-7d192578c057.smil/playlist.m3u8"
+                },
+        "updatedAt":1538086900489,
+        "status":"started",
+        "maxDuration":7200,
+        "resolution":"640x480",
+        "partnerId":100,
+        "event":"broadcast",
+        "multiBroadcastTag":"broadcast-1"
+        }
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_Broadcasts/starts_a_broadcast_with_a_multi_broadcast_tag_tag_value_of_nil_when_multiBroadcastTag_is_not_specified.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/starts_a_broadcast_with_a_multi_broadcast_tag_tag_value_of_nil_when_multiBroadcastTag_is_not_specified.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: '{"sessionId":"SESSIONID","outputs":{"hls":{}}}'
     headers:
       User-Agent:
-      - OpenTok-Ruby-SDK/4.4.0-Ruby-Version-3.0.0-p0
+      - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:

--- a/spec/cassettes/OpenTok_Broadcasts/starts_a_broadcast_with_a_multi_broadcast_tag_tag_value_of_nil_when_multiBroadcastTag_is_not_specified.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/starts_a_broadcast_with_a_multi_broadcast_tag_tag_value_of_nil_when_multiBroadcastTag_is_not_specified.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/broadcast
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID","outputs":{"hls":{}}}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/4.4.0-Ruby-Version-3.0.0-p0
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 03 Oct 2022 11:11:31 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+        "id":"BROADCASTID",
+        "sessionId":"SESSIONID",
+        "projectId":123456,
+        "createdAt":1538086900154,
+        "broadcastUrls":
+                {
+                "hls":"https://cdn-broadcast001-pdx.tokbox.com/14787/14787_b930bf08-1c9f-4c55-ab04-7d192578c057.smil/playlist.m3u8"
+                },
+        "updatedAt":1538086900489,
+        "status":"started",
+        "maxDuration":7200,
+        "resolution":"640x480",
+        "partnerId":100,
+        "event":"broadcast"
+        }
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_Broadcasts/starts_a_broadcast_with_a_specified_multiBroadcastTag.yml
+++ b/spec/cassettes/OpenTok_Broadcasts/starts_a_broadcast_with_a_specified_multiBroadcastTag.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/broadcast
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID","outputs":{"hls":{}},"multiBroadcastTag":"broadcast-1"}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 07 Sep 2022 13:52:17 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+        "id":"BROADCASTID",
+        "sessionId":"SESSIONID",
+        "projectId":123456,
+        "createdAt":1538086900154,
+        "broadcastUrls":
+                {
+                "hls":"https://cdn-broadcast001-pdx.tokbox.com/14787/14787_b930bf08-1c9f-4c55-ab04-7d192578c057.smil/playlist.m3u8"
+                },
+        "updatedAt":1538086900489,
+        "status":"started",
+        "maxDuration":7200,
+        "resolution":"640x480",
+        "partnerId":100,
+        "event":"broadcast",
+        "multiBroadcastTag":"broadcast-1"
+        }
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -50,6 +50,19 @@ describe OpenTok::Archives do
     expect(archive.multiArchiveTag).to eq archive_tag
   end
 
+  it "should create an archives with a matching multi_archive_tag tag value when multiArchiveTag is specified", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    archive_tag = 'archive-1'
+    archive = archives.create session_id, :multiArchiveTag => archive_tag
+    expect(archive).to be_an_instance_of OpenTok::Archive
+    expect(archive.multi_archive_tag).to eq archive_tag
+  end
+
+  it "should create an archives with a multi_archive_tag tag value of nil when multiArchiveTag is not specified", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    archive = archives.create session_id
+    expect(archive).to be_an_instance_of OpenTok::Archive
+    expect(archive.multi_archive_tag).to be_nil
+  end
+
   it "should create audio only archives", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" } } do
     archive = archives.create session_id, :has_video => false
     expect(archive).to be_an_instance_of OpenTok::Archive

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -42,6 +42,14 @@ describe OpenTok::Archives do
     expect(archive.name).to eq archive_name
   end
 
+  it "should create an archives with a specified multiArchiveTag", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    archive_tag = 'archive-1'
+    archive = archives.create session_id, :multiArchiveTag => archive_tag
+    expect(archive).to be_an_instance_of OpenTok::Archive
+    expect(archive.session_id).to eq session_id
+    expect(archive.multiArchiveTag).to eq archive_tag
+  end
+
   it "should create audio only archives", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" } } do
     archive = archives.create session_id, :has_video => false
     expect(archive).to be_an_instance_of OpenTok::Archive

--- a/spec/opentok/broadcasts_spec.rb
+++ b/spec/opentok/broadcasts_spec.rb
@@ -93,6 +93,20 @@ describe OpenTok::Broadcasts do
     expect(b_rtmp.broadcastUrls["rtmp"].count).to eq 1
   end
 
+  it 'starts a broadcast with a specified multiBroadcastTag', :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    broadcast_tag = 'broadcast-1'
+    opts = {
+        :outputs => {
+            :hls => {}
+        },
+        :multiBroadcastTag => broadcast_tag
+    }
+    broadcast_1 = broadcast.create(session_id, opts)
+    expect(broadcast_1).to be_an_instance_of OpenTok::Broadcast
+    expect(broadcast_1.id).to eq broadcast_id
+    expect(broadcast_1.multiBroadcastTag).to eq broadcast_tag
+  end
+
   it 'finds a broadcast', :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
     b = broadcast.find started_broadcast_id
     expect(b).to be_an_instance_of OpenTok::Broadcast

--- a/spec/opentok/broadcasts_spec.rb
+++ b/spec/opentok/broadcasts_spec.rb
@@ -107,6 +107,30 @@ describe OpenTok::Broadcasts do
     expect(broadcast_1.multiBroadcastTag).to eq broadcast_tag
   end
 
+  it 'starts a broadcast with a matching multi_broadcast_tag value when multiBroadcastTag is specified', :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    broadcast_tag = 'broadcast-1'
+    opts = {
+        :outputs => {
+            :hls => {}
+        },
+        :multiBroadcastTag => broadcast_tag
+    }
+    broadcast_1 = broadcast.create(session_id, opts)
+    expect(broadcast_1).to be_an_instance_of OpenTok::Broadcast
+    expect(broadcast_1.multi_broadcast_tag).to eq broadcast_tag
+  end
+
+  it 'starts a broadcast with a multi_broadcast_tag tag value of nil when multiBroadcastTag is not specified', :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    opts = {
+        :outputs => {
+            :hls => {}
+        }
+    }
+    broadcast_1 = broadcast.create(session_id, opts)
+    expect(broadcast_1).to be_an_instance_of OpenTok::Broadcast
+    expect(broadcast_1.multi_broadcast_tag).to be_nil
+  end
+
   it 'finds a broadcast', :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
     b = broadcast.find started_broadcast_id
     expect(b).to be_an_instance_of OpenTok::Broadcast


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds code comments for the `multiArchiveTag` and `multiBroadcastTag` properties when creating Archives and Broadcasts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To keep the code comments in line with the actual options specified in the documentation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added tests to ensure that Archives can be created with a `multiArchiveTag` specified and Broadcasts can be created with a `multiBroadcastTag` specified.
