### PR TITLE
DEVX-6810: Add support for E2EE

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ session = opentok.create_session :location => '12.34.56.78'
 # A session with automatic archiving (must use the routed media mode):
 session = opentok.create_session :archive_mode => :always, :media_mode => :routed
 
+# A session with end-to-end encryption (must use the routed media mode):
+session = opentok.create_session :e2ee => true, :media_mode => :routed
+
 # Store this sessionId in the database for later use:
 session_id = session.session_id
 ```
@@ -322,7 +325,7 @@ For more information on archiving, see the
 
 ### Signaling
 
-You can send a signal using the `opentok.signals.send(session_id, connection_id, opts)` method.  
+You can send a signal using the `opentok.signals.send(session_id, connection_id, opts)` method.
 If `connection_id` is nil or an empty string, then the signal is send to all valid connections in
 the session.
 
@@ -457,7 +460,7 @@ You can cause a client to be forced to disconnect from a session by using the
 
 ### Forcing clients in a session to mute published audio
 
-You can force the publisher of a specific stream to stop publishing audio using the 
+You can force the publisher of a specific stream to stop publishing audio using the
 `opentok.streams.force_mute(session_id, stream_id)` method.
 
 You can force the publisher of all streams in a session (except for an optional list of streams)

--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -145,8 +145,8 @@ module OpenTok
     #     archiving, the session must use the <code>:routed</code> media mode.
     #
     # @option opts [true, false] :e2ee
-    #     (Boolean, optional) — whether the session is end-to-end encrypted from client to client (default: false).
-    #     Should not be set to `true` if `:media_mode` is `:relayed` or if `:archive_mode` is `:always`.
+    #     (Boolean, optional) — Whether the session uses end-to-end encryption from client to client (default: false).
+    #     This should not be set to `true` if `:media_mode` is `:relayed`.
     #     See the {https://tokbox.com/developer/guides/end-to-end-encryption/ documentation} for more information.
     #
     # @return [Session] The Session object. The session_id property of the object is the session ID.

--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -159,6 +159,13 @@ module OpenTok
       # keep opts around for Session constructor, build REST params
       params = opts.clone
 
+      # validate input combinations
+      raise ArgumentError, "A session with always archive mode must also have the routed media mode." if (params[:archive_mode] == :always && params[:media_mode] == :relayed)
+
+      raise ArgumentError, "A session with relayed media mode should not have e2ee set to true." if (params[:media_mode] == :relayed && params[:e2ee] == true)
+
+      raise ArgumentError, "A session with always archive mode must not have e2ee set to true." if (params[:archive_mode] == :always && params[:e2ee] == true)
+
       # anything other than :relayed sets the REST param to "disabled", in which case we force
       # opts to be :routed. if we were more strict we could raise an error when the value isn't
       # either :relayed or :routed
@@ -176,8 +183,6 @@ module OpenTok
       unless params[:archive_mode].nil?
         raise "archive mode must be either always or manual" unless ARCHIVE_MODES.include? params[:archive_mode].to_sym
       end
-
-      raise "A session with always archive mode must also have the routed media mode." if (params[:archive_mode] == :always && params[:media_mode] == :relayed)
 
       response = client.create_session(params)
       Session.new api_key, api_secret, response['sessions']['Session']['session_id'], opts

--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -148,7 +148,7 @@ module OpenTok
     def create_session(opts={})
 
       # normalize opts so all keys are symbols and only include valid_opts
-      valid_opts = [ :media_mode, :location, :archive_mode ]
+      valid_opts = [ :media_mode, :location, :archive_mode, :e2ee ]
       opts = opts.inject({}) do |m,(k,v)|
         if valid_opts.include? k.to_sym
           m[k.to_sym] = v

--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -144,6 +144,11 @@ module OpenTok
     #     automatically (<code>:always</code>) or not (<code>:manual</code>). When using automatic
     #     archiving, the session must use the <code>:routed</code> media mode.
     #
+    # @option opts [true, false] :e2ee
+    #     (Boolean, optional) — whether the session is end-to-end encrypted from client to client (default: false).
+    #     Should not be set to `true` if `:media_mode` is `:relayed` or if `:archive_mode` is `:always`.
+    #     See the {https://tokbox.com/developer/guides/end-to-end-encryption/ documentation} for more information.
+    #
     # @return [Session] The Session object. The session_id property of the object is the session ID.
     def create_session(opts={})
 

--- a/lib/opentok/session.rb
+++ b/lib/opentok/session.rb
@@ -57,7 +57,7 @@ module OpenTok
       :session_id => ->(instance) { instance.session_id }
     })
 
-    attr_reader :session_id, :media_mode, :location, :archive_mode, :api_key, :api_secret
+    attr_reader :session_id, :media_mode, :location, :archive_mode, :e2ee, :api_key, :api_secret
 
     # @private
     # this implementation doesn't completely understand the format of a Session ID
@@ -73,7 +73,7 @@ module OpenTok
     # @private
     def initialize(api_key, api_secret, session_id, opts={})
       @api_key, @api_secret, @session_id = api_key, api_secret, session_id
-      @media_mode, @location, @archive_mode = opts.fetch(:media_mode, :relayed), opts[:location], opts.fetch(:archive_mode, :manual)
+      @media_mode, @location, @archive_mode, @e2ee = opts.fetch(:media_mode, :relayed), opts[:location], opts.fetch(:archive_mode, :manual), opts.fetch(:e2ee, :false)
     end
 
     # @private

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_e2ee_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_e2ee_sessions.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/session/create
+    body:
+      encoding: UTF-8
+      string: e2ee=true&p2p.preference=disabled
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+      Accept: "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 18 Apr 2023 16:17:40 GMT
+      Content-Type:
+      - text/xml
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - '*'
+      X-Tb-Host:
+      - mantis503-nyc.tokbox.com
+      Content-Length:
+      - '304'
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><sessions><Session><session_id>1_MX4xMjM0NTZ-MTIuMzQuNTYuNzh-TW9uIE1hciAxNyAwMTo0ODo1NSBQRFQgMjAxNH4wLjM0MTM0MzE0MDIyOTU4Mjh-</session_id><partner_id>123456</partner_id><create_dt>Tue
+        Apr 18 08:17:40 PDT 2023</create_dt></Session></sessions>
+  recorded_at: Tue, 18 Apr 2023 16:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/opentok/opentok_spec.rb
+++ b/spec/opentok/opentok_spec.rb
@@ -114,9 +114,33 @@ describe OpenTok::OpenTok do
         expect(session.location).to eq nil
       end
 
+      # context "with relayed media mode and always archive mode" do
+      #   subject { -> { session = opentok.create_session :archive_mode => :always, :media_mode => :relayed }}
+      #   it { should raise_error }
+      # end
+
       context "with relayed media mode and always archive mode" do
-        subject { -> { session = opentok.create_session :archive_mode => :always, :media_mode => :relayed }}
-        it { should raise_error }
+        it "raises an error" do
+          expect {
+            opentok.create_session :archive_mode => :always, :media_mode => :relayed
+          }.to raise_error ArgumentError
+        end
+      end
+
+      context "with relayed media mode and e2ee set to true" do
+        it "raises an error" do
+          expect {
+            opentok.create_session :media_mode => :relayed, :e2ee => true
+          }.to raise_error ArgumentError
+        end
+      end
+
+      context "with always archive mode and e2ee set to true" do
+        it "raises an error" do
+          expect {
+            opentok.create_session :archive_mode => :always, :e2ee => true
+          }.to raise_error ArgumentError
+        end
       end
 
     end

--- a/spec/opentok/opentok_spec.rb
+++ b/spec/opentok/opentok_spec.rb
@@ -97,11 +97,20 @@ describe OpenTok::OpenTok do
         expect(session.media_mode).to eq :relayed
         expect(session.location).to eq nil
       end
+
       it "creates always archived sessions", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
         session = opentok.create_session :media_mode => :routed, :archive_mode => :always
         expect(session).to be_an_instance_of OpenTok::Session
         expect(session.session_id).to be_an_instance_of String
         expect(session.archive_mode).to eq :always
+        expect(session.location).to eq nil
+      end
+
+      it "creates e2ee sessions", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+        session = opentok.create_session :media_mode => :routed, :e2ee => :true
+        expect(session).to be_an_instance_of OpenTok::Session
+        expect(session.session_id).to be_an_instance_of String
+        expect(session.e2ee).to eq :true
         expect(session.location).to eq nil
       end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR does the following:

- Updates the `Opentok#create_session` method to:
  - Add an option for `:e2ee` to `valid_opts`
  - Adds conditional checks to the method ensure `:e2ee` is not set to `true` if `:media_mode` is `:relayed` or if `:archive_mode` is `:always`
  - Update the docs comments to provide information on the new param and a link to the relevant OpenTok documentation
 
- Adds unit tests for the new functionality described above


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It implements a feature in the SDK which is being added to the API.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a number tests for calling `Opentok#create_session` with the new `:e2ee` param set, as well as tests for invalid configuration options

## Example Output or Screenshots (if appropriate):

n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
