### PR TITLE
DEVX-6817: Auto Archive Improvements

### DIFF
--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -144,6 +144,16 @@ module OpenTok
     #     automatically (<code>:always</code>) or not (<code>:manual</code>). When using automatic
     #     archiving, the session must use the <code>:routed</code> media mode.
     #
+    # @option opts [Symbol] :archive_name The name to use for archives in auto-archived sessions.
+    #     When setting this option, the :archive_mode option must be set to :always or an error will result.
+    #     The length of the archive name can be up to 80 chars.
+    #     Due to encoding limitations the following special characters are translated to a colon (:) character: ~, -, _.
+    #     If you do not set a name and the archiveMode option is set to always, the archive name will be empty.
+    #
+    # @option opts [Symbol] :archive_resolution The resolution of archives in an auto-archived session.
+    #     Valid values are "480x640", "640x480" (the default), "720x1280", "1280x720", "1080x1920", and "1920x1080".
+    #     When setting this option, the :archive_mode option must be set to :always or an error will result.
+    #
     # @option opts [true, false] :e2ee
     #     (Boolean, optional) — Whether the session uses end-to-end encryption from client to client (default: false).
     #     This should not be set to `true` if `:media_mode` is `:relayed`.

--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -163,7 +163,7 @@ module OpenTok
     def create_session(opts={})
 
       # normalize opts so all keys are symbols and only include valid_opts
-      valid_opts = [ :media_mode, :location, :archive_mode, :e2ee ]
+      valid_opts = [ :media_mode, :location, :archive_mode, :archive_name, :archive_resolution, :e2ee ]
       opts = opts.inject({}) do |m,(k,v)|
         if valid_opts.include? k.to_sym
           m[k.to_sym] = v
@@ -197,6 +197,7 @@ module OpenTok
       # archive mode is optional, but it has to be one of the valid values if present
       unless params[:archive_mode].nil?
         raise "archive mode must be either always or manual" unless ARCHIVE_MODES.include? params[:archive_mode].to_sym
+        raise ArgumentError, "archive name and/or archive resolution must not be set if archive mode is manual" if params[:archive_mode] == :manual && (params[:archive_name] || params[:archive_resolution])
       end
 
       response = client.create_session(params)

--- a/lib/opentok/session.rb
+++ b/lib/opentok/session.rb
@@ -20,6 +20,10 @@ module OpenTok
   # @attr_reader [String] archive_mode Whether the session will be archived automatically
   #  (<code>:always</code>) or not (<code>:manual</code>).
   #
+  # @attr_reader [String] archive_name The name to use for archives in auto-archived sessions.
+  #
+  # @attr_reader [String] :archive_resolution The resolution of archives in an auto-archived session.
+  #
   # @!method generate_token(options)
   #   Generates a token.
   #
@@ -57,7 +61,7 @@ module OpenTok
       :session_id => ->(instance) { instance.session_id }
     })
 
-    attr_reader :session_id, :media_mode, :location, :archive_mode, :e2ee, :api_key, :api_secret
+    attr_reader :session_id, :media_mode, :location, :archive_mode, :archive_name, :archive_resolution, :e2ee, :api_key, :api_secret
 
     # @private
     # this implementation doesn't completely understand the format of a Session ID
@@ -73,7 +77,12 @@ module OpenTok
     # @private
     def initialize(api_key, api_secret, session_id, opts={})
       @api_key, @api_secret, @session_id = api_key, api_secret, session_id
-      @media_mode, @location, @archive_mode, @e2ee = opts.fetch(:media_mode, :relayed), opts[:location], opts.fetch(:archive_mode, :manual), opts.fetch(:e2ee, :false)
+      @media_mode = opts.fetch(:media_mode, :relayed)
+      @location = opts[:location]
+      @archive_mode = opts.fetch(:archive_mode, :manual)
+      @archive_name = opts.fetch(:archive_name, '') if archive_mode == :always
+      @archive_resolution = opts.fetch(:archive_resolution, "640x480") if archive_mode == :always
+      @e2ee = opts.fetch(:e2ee, :false)
     end
 
     # @private

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: archiveMode=always&archiveName=foo&p2p.preference=disabled
     headers:
       User-Agent:
-      - OpenTok-Ruby-SDK/4.6.0-Ruby-Version-3.0.0-p0
+      - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding:

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/session/create
+    body:
+      encoding: UTF-8
+      string: archiveMode=always&p2p.preference=disabled&archiveName=foo
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/4.6.0-Ruby-Version-3.0.0-p0
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 12 Jun 2023 16:17:36 GMT
+      Content-Type:
+      - text/xml
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - '*'
+      X-Tb-Host:
+      - fms503-nyc.tokbox.com
+      Content-Length:
+      - '282'
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><sessions><Session><session_id>1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg</session_id><partner_id>123456</partner_id><create_dt>Mon
+        Jun 12 16:17:36 GMT 2023</create_dt></Session></sessions>
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.opentok.com/session/create
     body:
       encoding: UTF-8
-      string: archiveMode=always&p2p.preference=disabled&archiveName=foo
+      string: archiveMode=always&archiveName=foo&p2p.preference=disabled
     headers:
       User-Agent:
       - OpenTok-Ruby-SDK/4.6.0-Ruby-Version-3.0.0-p0

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name_and_resolution.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name_and_resolution.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/session/create
+    body:
+      encoding: UTF-8
+      string: archiveMode=always&p2p.preference=disabled&archiveName=foo&archiveResolution=720x1280
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/4.6.0-Ruby-Version-3.0.0-p0
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 12 Jun 2023 16:17:36 GMT
+      Content-Type:
+      - text/xml
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - '*'
+      X-Tb-Host:
+      - fms503-nyc.tokbox.com
+      Content-Length:
+      - '282'
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><sessions><Session><session_id>1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg</session_id><partner_id>123456</partner_id><create_dt>Mon
+        Jun 12 16:17:36 GMT 2023</create_dt></Session></sessions>
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name_and_resolution.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name_and_resolution.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.opentok.com/session/create
     body:
       encoding: UTF-8
-      string: archiveMode=always&p2p.preference=disabled&archiveName=foo&archiveResolution=720x1280
+      string: archiveMode=always&archiveName=foo&archiveResolution=720x1280&p2p.preference=disabled
     headers:
       User-Agent:
       - OpenTok-Ruby-SDK/4.6.0-Ruby-Version-3.0.0-p0

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name_and_resolution.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name_and_resolution.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: archiveMode=always&archiveName=foo&archiveResolution=720x1280&p2p.preference=disabled
     headers:
       User-Agent:
-      - OpenTok-Ruby-SDK/4.6.0-Ruby-Version-3.0.0-p0
+      - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding:

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_resolution.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_resolution.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/session/create
+    body:
+      encoding: UTF-8
+      string: archiveMode=always&p2p.preference=disabled&archiveResolution=720x1280
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/4.6.0-Ruby-Version-3.0.0-p0
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 12 Jun 2023 16:17:36 GMT
+      Content-Type:
+      - text/xml
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - '*'
+      X-Tb-Host:
+      - fms503-nyc.tokbox.com
+      Content-Length:
+      - '282'
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><sessions><Session><session_id>1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg</session_id><partner_id>123456</partner_id><create_dt>Mon
+        Jun 12 16:17:36 GMT 2023</create_dt></Session></sessions>
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_resolution.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_resolution.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: archiveMode=always&archiveResolution=720x1280&p2p.preference=disabled
     headers:
       User-Agent:
-      - OpenTok-Ruby-SDK/4.6.0-Ruby-Version-3.0.0-p0
+      - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding:

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_resolution.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_resolution.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.opentok.com/session/create
     body:
       encoding: UTF-8
-      string: archiveMode=always&p2p.preference=disabled&archiveResolution=720x1280
+      string: archiveMode=always&archiveResolution=720x1280&p2p.preference=disabled
     headers:
       User-Agent:
       - OpenTok-Ruby-SDK/4.6.0-Ruby-Version-3.0.0-p0

--- a/spec/opentok/opentok_spec.rb
+++ b/spec/opentok/opentok_spec.rb
@@ -106,6 +106,34 @@ describe OpenTok::OpenTok do
         expect(session.location).to eq nil
       end
 
+      it "creates always archived sessions with a set archive name", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+        session = opentok.create_session :media_mode => :routed, :archive_mode => :always, :archive_name => 'foo'
+        expect(session).to be_an_instance_of OpenTok::Session
+        expect(session.session_id).to be_an_instance_of String
+        expect(session.archive_mode).to eq :always
+        expect(session.archive_name).to eq 'foo'
+        expect(session.location).to eq nil
+      end
+
+      it "creates always archived sessions with a set archive resolution", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+        session = opentok.create_session :media_mode => :routed, :archive_mode => :always, :archive_resolution => "720x1280"
+        expect(session).to be_an_instance_of OpenTok::Session
+        expect(session.session_id).to be_an_instance_of String
+        expect(session.archive_mode).to eq :always
+        expect(session.archive_resolution).to eq "720x1280"
+        expect(session.location).to eq nil
+      end
+
+      it "creates always archived sessions with a set archive name and resolution", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+        session = opentok.create_session :media_mode => :routed, :archive_mode => :always, :archive_name => 'foo', :archive_resolution => "720x1280"
+        expect(session).to be_an_instance_of OpenTok::Session
+        expect(session.session_id).to be_an_instance_of String
+        expect(session.archive_mode).to eq :always
+        expect(session.archive_name).to eq 'foo'
+        expect(session.archive_resolution).to eq "720x1280"
+        expect(session.location).to eq nil
+      end
+
       it "creates e2ee sessions", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
         session = opentok.create_session :media_mode => :routed, :e2ee => :true
         expect(session).to be_an_instance_of OpenTok::Session
@@ -114,15 +142,26 @@ describe OpenTok::OpenTok do
         expect(session.location).to eq nil
       end
 
-      # context "with relayed media mode and always archive mode" do
-      #   subject { -> { session = opentok.create_session :archive_mode => :always, :media_mode => :relayed }}
-      #   it { should raise_error }
-      # end
-
       context "with relayed media mode and always archive mode" do
         it "raises an error" do
           expect {
             opentok.create_session :archive_mode => :always, :media_mode => :relayed
+          }.to raise_error ArgumentError
+        end
+      end
+
+      context "with archive name set and manual archive mode" do
+        it "raises an error" do
+          expect {
+            opentok.create_session :archive_mode => :manual, :archive_name => 'foo'
+          }.to raise_error ArgumentError
+        end
+      end
+
+      context "with archive resolution set and manual archive mode" do
+        it "raises an error" do
+          expect {
+            opentok.create_session :archive_mode => :manual, :archive_resolution => "720x1280"
           }.to raise_error ArgumentError
         end
       end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR does the following:

- Updates the `Opentok#create_session` method to:
  - Add options for `:archive_name` and `archive_name` to `valid_opts`
  - Adds conditional checks to the method ensure `:archive_mode` is not set to `:manual` if `:archive_name` and/or `archive_name` are set
  - Update the docs comments to provide information on the new params

- Updates the `Session` class to:
  - Add instance variables for the new params in the `initialize` method
  - Add getter methods for the new params

- Adds unit tests for the new functionality described above

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It implements a feature in the SDK which has been added to the API.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a number tests for calling `Opentok#create_session` with the new params set, as well as tests for invalid configuration options

## Example Output or Screenshots (if appropriate):

n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
