### PR TITLE
Accept all valid options for archive creation.

### DIFF
--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -97,7 +97,16 @@ module OpenTok
         "Resolution cannot be supplied for individual output mode" if options.key?(:resolution) and options[:output_mode] == :individual
 
       # normalize opts so all keys are symbols and only include valid_opts
-      valid_opts = [ :name, :has_audio, :has_video, :output_mode, :resolution, :layout ]
+      valid_opts = [
+        :name,
+        :has_audio,
+        :has_video,
+        :output_mode,
+        :resolution,
+        :layout,
+        :multiArchiveTag,
+        :streamMode
+      ]
       opts = options.inject({}) do |m,(k,v)|
         if valid_opts.include? k.to_sym
           m[k.to_sym] = v

--- a/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_matching_multi_archive_tag_when_multiArchiveTag_is_specified.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_matching_multi_archive_tag_when_multiArchiveTag_is_specified.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.opentok.com/v2/project/123456/archive
     body:
       encoding: UTF-8
-      string: '{"sessionId":"SESSIONID"}'
+      string: '{"sessionId":"SESSIONID","multiArchiveTag":"archive-1"}'
     headers:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>

--- a/spec/cassettes/OpenTok_Archives/should_create_an_archives_with_a_specified_multiArchiveTag.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_an_archives_with_a_specified_multiArchiveTag.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.opentok.com/v2/project/123456/archive
     body:
       encoding: UTF-8
-      string: '{"sessionId":"SESSIONID"}'
+      string: '{"sessionId":"SESSIONID","multiArchiveTag":"archive-1"}'
     headers:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>


### PR DESCRIPTION
Fixes issue #268 

The tests on the repo are deceptive, you can remove setting multiArchiveTag at all and they will still work since the VCR response has the archive tag set in the response.

This PR allows these attributes correctly through creation and ensures they are passed on to the http request to the api.