### PR TITLE
Release 4.8.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 4.8.1
+
+* Fixes a bug with the `Archives#create` method. See [#269](https://github.com/opentok/OpenTok-Ruby-SDK/pull/269) and [#270](https://github.com/opentok/OpenTok-Ruby-SDK/pull/270)
+
 # 4.8.0
 
 * Add support for Captions API [#267](https://github.com/opentok/OpenTok-Ruby-SDK/pull/267)

--- a/lib/opentok/archive.rb
+++ b/lib/opentok/archive.rb
@@ -72,13 +72,14 @@ module OpenTok
     #   set to null. The download URL is obfuscated, and the file is only available from the URL for
     #   10 minutes. To generate a new URL, call the Archive.listArchives() or OpenTok.getArchive() method.
   class Archive
-    attr_reader :multi_archive_tag
+    attr_reader :multi_archive_tag, :stream_mode
     # @private
     def initialize(interface, json)
       @interface = interface
       # TODO: validate json fits schema
       @json = json
       @multi_archive_tag = @json['multiArchiveTag']
+      @stream_mode = @json['streamMode']
     end
 
     # A JSON-encoded string representation of the archive.

--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -39,11 +39,11 @@ module OpenTok
     #   (a video track is included). If you set both  <code>has_audio</code> and
     #   <code>has_video</code> to <code>false</code>, the call to the <code>create()</code>
     #   method results in an error.
-    # @option options [String] :multiArchiveTag (Optional) Set this to support recording multiple archives for the same session simultaneously. 
+    # @option options [String] :multi_archive_tag (Optional) Set this to support recording multiple archives for the same session simultaneously. 
     #    Set this to a unique string for each simultaneous archive of an ongoing session. You must also set this option when manually starting an archive 
     #    that is {https://tokbox.com/developer/guides/archiving/#automatic automatically archived}. Note that the `multiArchiveTag` value is not included
     #    in the response for the methods to {https://tokbox.com/developer/rest/#listing_archives list archives} and 
-    #    {https://tokbox.com/developer/rest/#retrieve_archive_info retrieve archive information}. If you do not specify a unique `multiArchiveTag`, 
+    #    {https://tokbox.com/developer/rest/#retrieve_archive_info retrieve archive information}. If you do not specify a unique `multi_archive_tag`, 
     #    you can only record one archive at a time for a given session. 
     #    {https://tokbox.com/developer/guides/archiving/#simultaneous-archives See Simultaneous archives}.
     # @option options [String] :output_mode Whether all streams in the archive are recorded
@@ -56,7 +56,7 @@ module OpenTok
     #  (HD portrait), or "1080x1920" (FHD portrait). This property only applies to composed archives. If you set
     #  this property and set the outputMode property to "individual", a call to the method
     #  results in an error.
-    # @option options [String] :streamMode (Optional) Whether streams included in the archive are selected
+    # @option options [String] :stream_mode (Optional) Whether streams included in the archive are selected
     #   automatically ("auto", the default) or manually ("manual"). When streams are selected automatically ("auto"),
     #   all streams in the session can be included in the archive. When streams are selected manually ("manual"),
     #   you specify streams to be included based on calls to the {Archives#add_stream} method. You can specify whether a
@@ -104,8 +104,8 @@ module OpenTok
         :output_mode,
         :resolution,
         :layout,
-        :multiArchiveTag,
-        :streamMode
+        :multi_archive_tag,
+        :stream_mode
       ]
       opts = options.inject({}) do |m,(k,v)|
         if valid_opts.include? k.to_sym

--- a/lib/opentok/version.rb
+++ b/lib/opentok/version.rb
@@ -1,4 +1,4 @@
 module OpenTok
   # @private
-  VERSION = '4.8.0'
+  VERSION = '4.8.1'
 end

--- a/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_streamMode_set_to_specified_stream_mode_value.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_streamMode_set_to_specified_stream_mode_value.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/archive
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID","streamMode":"manual"}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 03 Jan 2024 14:32:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "createdAt" : 1395183243556,
+          "duration" : 0,
+          "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+          "name" : "",
+          "partnerId" : 123456,
+          "reason" : "",
+          "sessionId" : "SESSIONID",
+          "size" : 0,
+          "status" : "started",
+          "url" : null,
+          "streamMode":"manual"
+        }
+  recorded_at: Tue, 18 Apr 2017 10:17:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -44,7 +44,7 @@ describe OpenTok::Archives do
 
   it "should create an archives with a specified multiArchiveTag", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
     archive_tag = 'archive-1'
-    archive = archives.create session_id, :multiArchiveTag => archive_tag
+    archive = archives.create session_id, :multi_archive_tag => archive_tag
     expect(archive).to be_an_instance_of OpenTok::Archive
     expect(archive.session_id).to eq session_id
     expect(archive.multiArchiveTag).to eq archive_tag
@@ -52,7 +52,7 @@ describe OpenTok::Archives do
 
   it "should create an archive with matching multi_archive_tag when multiArchiveTag is specified", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
     archive_tag = 'archive-1'
-    archive = archives.create session_id, :multiArchiveTag => archive_tag
+    archive = archives.create session_id, :multi_archive_tag => archive_tag
     expect(archive).to be_an_instance_of OpenTok::Archive
     expect(archive.multi_archive_tag).to eq archive_tag
   end
@@ -61,6 +61,13 @@ describe OpenTok::Archives do
     archive = archives.create session_id
     expect(archive).to be_an_instance_of OpenTok::Archive
     expect(archive.multi_archive_tag).to be_nil
+  end
+
+  it "should create an archive with streamMode set to specified stream_mode value", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    stream_mode = 'manual'
+    archive = archives.create session_id, :stream_mode => stream_mode
+    expect(archive).to be_an_instance_of OpenTok::Archive
+    expect(archive.stream_mode).to eq stream_mode
   end
 
   it "should create audio only archives", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" } } do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR follows on from #269 to provide more idiomatic usage of `options` hash for the `Archives#create` method. Specifically it:

- Changes `multi_archive_tag` and `stream_mode` in the `valid_opts` array defined in  `Archives#create` to snake_case from camelCase
- Adds an ivar and attr_accessor for `stream_mode` in the `Archive` class
- Adds a test for creating an archive with a specific `stream_mode`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#269 fixed a bug whereby the `mutliArchiveTag` and `streamMode` properties weren't being passed to the API endpoint. This PR makes the setting of those properties via the `Archives#create` method more idiomatic.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests added and//or ammended to test the functionality.

## Example Output or Screenshots (if appropriate):

n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
