### PR TITLE
DEVX-8994: Update expire time logic in JWT client token generator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 4.10.1
+
+* Updating expire time logic in JWT client token generator. See [#285](https://github.com/opentok/OpenTok-Ruby-SDK/pull/285)
+
 # 4.10.0
 
 * Updating client token creation to use JWTs by default. See [#274](https://github.com/opentok/OpenTok-Ruby-SDK/pull/274)

--- a/lib/opentok/token_generator.rb
+++ b/lib/opentok/token_generator.rb
@@ -126,7 +126,6 @@ module OpenTok
         :iss => api_key,
         :ist => "project",
         :iat => Time.now.to_i,
-        :exp => Time.now.to_i + 86400,
         :nonce => Random.rand,
         :role => role,
         :scope => "session.connect",

--- a/lib/opentok/version.rb
+++ b/lib/opentok/version.rb
@@ -1,4 +1,4 @@
 module OpenTok
   # @private
-  VERSION = '4.10.0'
+  VERSION = '4.10.1'
 end


### PR DESCRIPTION
This PR updates the expire time logic in the JWT client token genertor. Specifically it removes the default `exp` param from the JWT payload so the `exp` is not set unless `expire_time` is passed as an option to the token generator method call.