### PR TITLE
DEVX-9004: Implementing max bitrate for archives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 4.12.0
+
+* Updating the `Archives#create` method to allow `max_bitrate` as an option. See [#288](https://github.com/opentok/OpenTok-Ruby-SDK/pull/288)
+
 # 4.11.0
 
 * Updating client token creation to use JWTs by default. See [#287](https://github.com/opentok/OpenTok-Ruby-SDK/pull/274)

--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -79,6 +79,10 @@ module OpenTok
     #   layout type. For more information, see
     #   {https://tokbox.com/developer/guides/archiving/layout-control.html Customizing
     #   the video layout for composed archives}.
+    # @option options [Integer] :max_bitrate (Optional) The maximum video bitrate for the archive, in bits per second. The minimum 
+    #   value is 100,000 and the maximum is 6,000,000. This option is only valid for composed archives. Set the maximum video bitrate
+    #   to control the size of the composed archive. This maximum bitrate applies to the video bitrate only. If the output archive has
+    #   audio, those bits will be excluded from the limit.
     #
     # @return [Archive] The Archive object, which includes properties defining the archive,
     #   including the archive ID.
@@ -105,7 +109,8 @@ module OpenTok
         :resolution,
         :layout,
         :multi_archive_tag,
-        :stream_mode
+        :stream_mode,
+        :max_bitrate
       ]
       opts = options.inject({}) do |m,(k,v)|
         if valid_opts.include? k.to_sym

--- a/lib/opentok/version.rb
+++ b/lib/opentok/version.rb
@@ -1,4 +1,4 @@
 module OpenTok
   # @private
-  VERSION = '4.11.0'
+  VERSION = '4.12.0'
 end

--- a/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_maxBitrate_set_to_specified_max_bitrate_value.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_maxBitrate_set_to_specified_max_bitrate_value.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/archive
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID","maxBitrate":200000}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 07 Feb 2025 12:17:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "createdAt" : 1395183243556,
+          "duration" : 0,
+          "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+          "name" : "",
+          "partnerId" : 123456,
+          "reason" : "",
+          "sessionId" : "SESSIONID",
+          "size" : 0,
+          "status" : "started",
+          "url" : null,
+          "maxBitrate": 200000
+        }
+  recorded_at: Fri, 07 Feb 2025 12:17:20 GMT
+recorded_with: VCR 6.0.0

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -70,6 +70,13 @@ describe OpenTok::Archives do
     expect(archive.stream_mode).to eq stream_mode
   end
 
+  it "should create an archive with maxBitrate set to specified max_bitrate value", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+    max_bitrate = 200000
+    archive = archives.create session_id, :max_bitrate => max_bitrate
+    expect(archive).to be_an_instance_of OpenTok::Archive
+    expect(archive.max_bitrate).to eq max_bitrate
+  end
+
   it "should create audio only archives", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" } } do
     archive = archives.create session_id, :has_video => false
     expect(archive).to be_an_instance_of OpenTok::Archive


### PR DESCRIPTION
This PR adds the ability to set a `maxBitrate` property when creating an archive. Specifically it:

- Updates the `Archives#create` method to allow `max_bitrate` as a valid option
- Updates the code comments on that method to explain the option
- Adds a unit test for creating an archive with a specific max bitrate