### PR TITLE
minor docs edits

### DIFF
--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -36,7 +36,6 @@ module OpenTok
   #     the token.
   #
   #   @param [Hash] options A hash defining options for the token.
-  #   @option options [String] :token_type The type of token to generate. Must be one of 'T1' or 'JWT'. 'JWT' is the default.
   #   @option options [Symbol] :role The role for the token. Set this to one of the following
   #     values:
   #     * <code>:subscriber</code> -- A subscriber can only subscribe to streams.
@@ -60,6 +59,7 @@ module OpenTok
   #     published by the client. Layout classes are used in customizing the layout of videos in
   #     {https://tokbox.com/developer/guides/broadcast/live-streaming/ live streaming broadcasts}
   #     and {https://tokbox.com/developer/guides/archiving/layout-control.html composed archives}.
+  #   @option options [String] :token_type The type of token to generate. Must be one of 'T1' or 'JWT'. 'JWT' is the default.
   #   @return [String] The token string.
   class OpenTok
 

--- a/lib/opentok/session.rb
+++ b/lib/opentok/session.rb
@@ -36,6 +36,9 @@ module OpenTok
   #     * <code>:publisher</code> -- A publisher can publish streams, subscribe to
   #       streams, and signal. (This is the default value if you do not specify a role.)
   #
+  #     * <code>:publisheronly</code> -- A client connected with a publisheronly token
+  #       can publish streams but cannot subscribe to streams.
+  #
   #     * <code>:moderator</code> -- n addition to the privileges granted to a
   #       publisher, a moderator can perform moderation functions, such as forcing clients
   #       to disconnect, to stop publishing streams, or to mute audio in published streams. See the


### PR DESCRIPTION
Adds some missing content and de-emphasizes the `token_type` option.