### PR TITLE
feat: Add List Connections and Implement Vonage Wrapper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 4.14.0
+
+* Implements functionality to allow the use of Vonage Video endpoints and credentials.
+* Adds a `Connections#list` method to allow the listing of connections to a session. 
+* Adds support for the 24KHz `audio_rate` for `WebSocket` connections
+
+See [#295](https://github.com/opentok/OpenTok-Ruby-SDK/pull/295)
+
 # 4.13.0
 
 * Updating the `Archives#create` method to allow `quantization_parameter` as an option, and the `WebSocket#connect`  method to allow `bidirectional` as an option. See [#290](https://github.com/opentok/OpenTok-Ruby-SDK/pull/290)

--- a/README.md
+++ b/README.md
@@ -486,10 +486,42 @@ for more details.
 You can also change the layout of an individual stream dynamically. Refer to
 [working with Streams](#working-with-streams).
 
-### Force disconnect
+### Working with Connections
+
+#### Listing Connections
+
+You can retrieve a list of clients connected to a session using the `OpenTok::Connetions#list` method, passing in the Session ID of the session, for example:
+
+```ruby
+connection_list = opentok.connections.list('abcdefg12345')
+```
+
+This will return an iterable `ConnectionList` object with `total` and `session_id` getter methods:
+
+```ruby
+connection_list.total # => 5
+connection_list.session_id # => 'abcdefg12345'
+```
+
+The items in the connection list are `Connection` objects, each representing a client connection to the session. You can access data on individual connection objects:
+
+```ruby
+connection_1 = connection_list.first
+connection_1.connection_id # => "249b7640-1bcf-4f49-8fc7-3d7998ff218b"
+connection_1.connection_state # => "Connected"
+connection_1.created_at # =>  1779287104931
+```
+
+#### Force disconnect
 
 You can cause a client to be forced to disconnect from a session by using the
-`opentok.connections.forceDisconnect(session_id, connection_id)` method.
+`opentok.connections.forceDisconnect(session_id, connection_id)` method and passing in the Session ID and Connection ID.
+
+You can also call the `Connection#force_disconnect` method on a `Connection` object returned when listing connections:
+
+```ruby
+connection_1.force_disconnect
+```
 
 ### Forcing clients in a session to mute published audio
 

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ You can also change the layout of an individual stream dynamically. Refer to
 
 #### Listing Connections
 
-You can retrieve a list of clients connected to a session using the `OpenTok::Connetions#list` method, passing in the Session ID of the session, for example:
+You can retrieve a list of clients connected to a session using the `OpenTok::Connections#list` method, passing in the Session ID of the session, for example:
 
 ```ruby
 connection_list = opentok.connections.list('abcdefg12345')

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The OpenTok Ruby SDK provides methods for:
 * [Forcing clients in a session to disconnect or mute published audio](https://tokbox.com/developer/guides/moderation/)
 * Working with OpenTok [Experience Composers](https://tokbox.com/developer/guides/experience-composer)
 * Working with OpenTok [Audio Connector](https://tokbox.com/developer/guides/audio-connector)
+* Using [Vonage Endpoints and Credentials](#using-vonage-endpoints-and-credentials)
 
 ## Note!
 
@@ -567,6 +568,27 @@ and `opentok.renders.list(options)` methods.
 
 You can start an [Audio Connector](https://tokbox.com/developer/guides/audio-connector) WebSocket
 by calling the `opentok.websocket.connect()` method.
+
+### Using Vonage Endpoints and Credentials
+
+You can use this library with the [Vonage Video API endpoints](https://developer.vonage.com/en/api/video) and Vonage credentials, instead of the TokBox endpoints and credentials.
+
+I order to do so, you will need to create a Vonage Application in order to generate an Application ID and Private Key. You can create a Vonage Application in the following ways:
+
+- Via the [Vonage Developer Dashboard](https://dashboard.nexmo.com/applications)
+- Using the [Vonage CLI](https://github.com/vonage/vonage-cli)
+- Using the [Vonage Application API](https://developer.vonage.com/application/code-snippets/application/create-application)
+
+Once you have the Application ID and Private Key, you can instantiate am `OpenTok` object as you normally would, using the Application ID in place of the API Key and the Private Key instead of the API Secret.
+Additionally, you need to specify in the options that the Vonage endpoints should be used:
+
+```ruby
+require "opentok"
+
+opentok = OpenTok::OpenTok.new application_id, private_key, :use_vonage_endpoints => true
+```
+
+You can then use the `OpenTok` object as you normally would to create sessions, generate client tokens, and perform other interactions with the API.
 
 ## Samples
 

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ by calling the `opentok.websocket.connect()` method.
 
 You can use this library with the [Vonage Video API endpoints](https://developer.vonage.com/en/api/video) and Vonage credentials, instead of the TokBox endpoints and credentials.
 
-I order to do so, you will need to create a Vonage Application in order to generate an Application ID and Private Key. You can create a Vonage Application in the following ways:
+In order to do so, you will need to create a Vonage Application in order to generate an Application ID and Private Key. You can create a Vonage Application in the following ways:
 
 - Via the [Vonage Developer Dashboard](https://dashboard.nexmo.com/applications)
 - Using the [Vonage CLI](https://github.com/vonage/vonage-cli)

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -5,7 +5,7 @@ require "opentok/version"
 
 require "active_support/inflector"
 require "httparty"
-require "jwt"
+require "vonage-jwt"
 
 module OpenTok
   # @private For internal use by the SDK.
@@ -16,6 +16,7 @@ module OpenTok
     # debug_output $stdout
 
     attr_accessor :api_key, :api_secret, :api_url, :ua_addendum, :timeout_length
+    attr_reader :use_vonage_endpoints
 
     def initialize(api_key, api_secret, api_url, ua_addendum='', opts={})
       self.class.base_uri api_url
@@ -26,6 +27,7 @@ module OpenTok
       @api_secret = api_secret
       @timeout_length = opts[:timeout_length] || 2
       self.class.open_timeout @timeout_length
+      @use_vonage_endpoints = opts[:use_vonage_endpoints] == true ? true : false
     end
 
     def generate_jwt(api_key, api_secret)
@@ -39,8 +41,16 @@ module OpenTok
       token
     end
 
+    def generate_vonage_jwt(api_key, api_secret)
+      Vonage::JWTBuilder.new(application_id: api_key, private_key: api_secret).jwt.generate
+    end
+
     def generate_headers(extra_headers = {})
-      defaults = { "X-OPENTOK-AUTH" => generate_jwt(@api_key, @api_secret) }
+      if use_vonage_endpoints == true
+        defaults = { "Authorization" => "Bearer #{generate_vonage_jwt(@api_key, @api_secret)}" }
+      else
+        defaults = { "X-OPENTOK-AUTH" => generate_jwt(@api_key, @api_secret) }
+      end
       defaults.merge extra_headers
     end
 

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -48,7 +48,7 @@ module OpenTok
       opts.extend(HashExtensions)
       response = self.class.post("/session/create", {
         :body => opts.camelize_keys!,
-        :headers => generate_headers
+        :headers => generate_headers("Content-Type" => "application/x-www-form-urlencoded")
       })
       case response.code
       when (200..300)

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -411,6 +411,28 @@ module OpenTok
 
     # Connections methods
 
+    def list_connections(session_id, offset, count)
+      query = Hash.new
+      query[:offset] = offset unless offset.nil?
+      query[:count] = count unless count.nil?
+      response = self.class.get("/v2/project/#{@api_key}/session/#{session_id}/connection", {
+        :query => query.empty? ? nil : query,
+        :headers => generate_headers
+      })
+      case response.code
+      when 200
+        response
+      when 400
+        raise ArgumentError, "List connections failed. Session ID #{session_id} is invalid"
+      when 403
+        raise OpenTokAuthenticationError, "Authentication failed while retrieving connections. API Key: #{@api_key}"
+      else
+        raise OpenTokConnectionError, "The connections could not be retrieved."
+      end
+    rescue StandardError => e
+      raise OpenTokError, "Failed to connect to OpenTok. Response code: #{e.message}"
+    end
+
     def forceDisconnect(session_id, connection_id)
       response = self.class.delete("/v2/project/#{@api_key}/session/#{session_id}/connection/#{connection_id}", {
           :headers => generate_headers("Content-Type" => "application/json")

--- a/lib/opentok/client.rb
+++ b/lib/opentok/client.rb
@@ -423,9 +423,11 @@ module OpenTok
       when 200
         response
       when 400
-        raise ArgumentError, "List connections failed. Session ID #{session_id} is invalid"
+        raise ArgumentError, "Invalid request. This response may indicate that some parameter of your query is invalid."
       when 403
         raise OpenTokAuthenticationError, "Authentication failed while retrieving connections. API Key: #{@api_key}"
+      when 404
+        raise OpenTokConnectionError, "Either the OpenTok session could not be found, or no clients are actively connected to the session."
       else
         raise OpenTokConnectionError, "The connections could not be retrieved."
       end

--- a/lib/opentok/connection.rb
+++ b/lib/opentok/connection.rb
@@ -1,0 +1,47 @@
+require "active_support/inflector"
+
+module OpenTok
+    # Represents a connection in an OpenTok session.
+    #
+    # @attr [String] connection_id
+    #   The ID of the connection.
+    #
+    # @attr [Integer] created_at
+    #   The timestamp when the connection was created, expressed in milliseconds since the Unix epoch.
+    #
+    # @attr [String] connection_state
+    #   The state of the connection.
+    #
+  class Connection
+    # @private
+    def initialize(interface, session_id, json)
+      @interface = interface
+      @session_id = session_id
+      # TODO: validate json fits schema
+      @json = json
+    end
+
+    # A JSON-encoded string representation of the connection.
+    def to_json
+      @json.to_json
+    end
+
+    # Forces the disconnection of this connection from the OpenTok session.
+    #
+    # A client must be actively connected to the OpenTok session for you to disconnect it.
+    def force_disconnect
+      # TODO: validate returned json fits schema
+      @json = @interface.forceDisconnect(@session_id, @json['connectionId'])
+    end
+
+    # @private ignore
+    def method_missing(method, *args, &block)
+      camelized_method = method.to_s.camelize(:lower)
+      if @json.has_key? camelized_method and args.empty?
+        @json[camelized_method]
+      else
+        super method, *args, &block
+      end
+    end
+  end
+end

--- a/lib/opentok/connection.rb
+++ b/lib/opentok/connection.rb
@@ -30,8 +30,7 @@ module OpenTok
     #
     # A client must be actively connected to the OpenTok session for you to disconnect it.
     def force_disconnect
-      # TODO: validate returned json fits schema
-      @json = @interface.forceDisconnect(@session_id, @json['connectionId'])
+      @interface.forceDisconnect(@session_id, @json['connectionId'])
     end
 
     # @private ignore

--- a/lib/opentok/connection_list.rb
+++ b/lib/opentok/connection_list.rb
@@ -4,7 +4,8 @@ module OpenTok
   # A class for accessing an array of Connection objects.
   class ConnectionList < Array
 
-    # The total number of connections.
+    # `total`: The total number of connections.
+    # `session_id`: The session ID of the session these connections belong to.
     attr_reader :total, :session_id
 
     # @private

--- a/lib/opentok/connection_list.rb
+++ b/lib/opentok/connection_list.rb
@@ -1,0 +1,18 @@
+require "opentok/connection"
+
+module OpenTok
+  # A class for accessing an array of Connection objects.
+  class ConnectionList < Array
+
+    # The total number of connections.
+    attr_reader :total, :session_id
+
+    # @private
+    def initialize(interface, json)
+      @total = json['count']
+      @session_id = json['sessionId']
+      super json['items'].map { |item| Connection.new interface, session_id, item }
+    end
+
+  end
+end

--- a/lib/opentok/connections.rb
+++ b/lib/opentok/connections.rb
@@ -1,9 +1,30 @@
+require "opentok/client"
+require "opentok/connection"
+require "opentok/connection_list"
+
 module OpenTok
   #  A class for working with OpenTok connections.
   class Connections
     # @private
     def initialize(client)
       @client = client
+    end
+
+    # Returns a ConnectionList, which is an array of connections that are active in a session,
+    # for your API key.
+    #
+    # @param [String] session_id The session ID of the OpenTok session.
+    # @param [Hash] options  A hash with keys defining which range of connections to retrieve.
+    # @option options [integer] :offset Optional. The index offset of the first connection. If you do not specify an offset, 0 is used.
+    # @option options [integer] :count Optional. The number of connections to be returned. The maximum
+    #   number of connections returned is 1000. If you do not specify a count, 50 is used.
+    #
+    # @return [ConnectionList] A ConnectionList object, which is an array of Connection objects.
+    def list(session_id, options = {})
+      raise ArgumentError, "session_id not provided" if session_id.to_s.empty?
+      raise ArgumentError, "count must be between 1 and 1000" if options[:count] && (options[:count] < 1 || options[:count] > 1000)
+      connections_list_json = @client.list_connections(session_id, options[:offset], options[:count])
+      ConnectionList.new self, connections_list_json
     end
 
     # Force a client to disconnect from an OpenTok session.
@@ -17,7 +38,7 @@ module OpenTok
     # @raise [OpenTokAuthenticationError] You are not authorized to disconnect the connection. Check your authentication credentials.
     # @raise [OpenTokConnectionError] The client specified by the connection_id  property is not connected to the session.
     #
-    def forceDisconnect(session_id, connection_id )
+    def forceDisconnect(session_id, connection_id)
       raise ArgumentError, "session_id not provided" if session_id.to_s.empty?
       raise ArgumentError, "connection_id not provided" if connection_id.to_s.empty?
       response = @client.forceDisconnect(session_id, connection_id)

--- a/lib/opentok/constants.rb
+++ b/lib/opentok/constants.rb
@@ -1,6 +1,7 @@
 module OpenTok
   require "set"
   API_URL = "https://api.opentok.com"
+  VONAGE_API_URL = "https://video.api.vonage.com"
   TOKEN_SENTINEL = "T1=="
   ROLES = { subscriber: "subscriber", publisher: "publisher", moderator: "moderator", publisheronly: "publisheronly" }
   ARCHIVE_MODES = ::Set.new([:manual, :always])

--- a/lib/opentok/opentok.rb
+++ b/lib/opentok/opentok.rb
@@ -87,8 +87,9 @@ module OpenTok
       @api_key = api_key.to_s()
       @api_secret = api_secret
       @timeout_length = opts[:timeout_length] || 2
-      @api_url = opts[:api_url] || API_URL
+      @api_url = set_api_url(opts)
       @ua_addendum = opts[:ua_addendum]
+      @use_vonage_endpoints = opts[:use_vonage_endpoints] == true ? true : false
     end
 
     # Creates a new OpenTok session and returns the session ID, which uniquely identifies
@@ -203,6 +204,7 @@ module OpenTok
       end
 
       response = client.create_session(params)
+      opts[:use_vonage_endpoints] = @use_vonage_endpoints
       Session.new api_key, api_secret, response['sessions']['Session']['session_id'], opts
     end
 
@@ -253,8 +255,18 @@ module OpenTok
 
     protected
     def client
-      @client ||= Client.new api_key, api_secret, api_url, ua_addendum, timeout_length: @timeout_length
+      @client ||= Client.new api_key, api_secret, api_url, ua_addendum, timeout_length: @timeout_length, use_vonage_endpoints: @use_vonage_endpoints
     end
 
+    private
+    def set_api_url(opts)
+      if opts[:api_url]
+        opts[:api_url]
+      elsif opts[:use_vonage_endpoints] == true
+        VONAGE_API_URL
+      else
+        API_URL
+      end
+    end
   end
 end

--- a/lib/opentok/session.rb
+++ b/lib/opentok/session.rb
@@ -87,6 +87,7 @@ module OpenTok
       @archive_name = opts.fetch(:archive_name, '') if archive_mode == :always
       @archive_resolution = opts.fetch(:archive_resolution, "640x480") if archive_mode == :always
       @e2ee = opts.fetch(:e2ee, :false)
+      @use_vonage_endpoints = opts[:use_vonage_endpoints] == true ? true : false
     end
 
     # @private

--- a/lib/opentok/token_generator.rb
+++ b/lib/opentok/token_generator.rb
@@ -6,12 +6,12 @@ require "addressable/uri"
 require "openssl"
 require "active_support"
 require "active_support/time"
-require "jwt"
+require "vonage-jwt"
 
 module OpenTok
   # @private
   module TokenGenerator
-    VALID_TOKEN_TYPES = ['T1', 'JWT'].freeze
+    VALID_TOKEN_TYPES = ['T1', 'JWT', 'VONAGE'].freeze
 
     # this works when using include TokenGenerator
     def self.included(base)
@@ -30,7 +30,6 @@ module OpenTok
       def generates_tokens(arg_lambdas={})
         @arg_lambdas = arg_lambdas
         define_method(:generate_token) do |*args|
-          # puts "generate_something is being called on #{self}. set up with #{method_opts.inspect}"
           dynamic_args = [ :api_key, :api_secret, :session_id, :token_opts ].map do |arg|
             self.class.arg_lambdas[arg].call(self) if self.class.arg_lambdas[arg]
           end
@@ -38,6 +37,8 @@ module OpenTok
           args = args.first(4-dynamic_args.length)
           token_type = if args.any? && args.last.is_a?(Hash) && args.last.has_key?(:token_type)
             args.last[:token_type].upcase
+          elsif @use_vonage_endpoints == true
+            "VONAGE"
           else
             "JWT"
           end
@@ -54,9 +55,15 @@ module OpenTok
 
       # Generates a token
       def generate_token(token_type)
-        token_type == 'T1' ? TokenGenerator::GENERATE_T1_TOKEN_LAMBDA : TokenGenerator::GENERATE_JWT_LAMBDA
+        case token_type
+        when 'T1'
+          TokenGenerator::GENERATE_T1_TOKEN_LAMBDA
+        when 'JWT'
+          TokenGenerator::GENERATE_JWT_LAMBDA
+        when 'VONAGE'
+          TokenGenerator::GENERATE_VONAGE_TOKEN_LAMBDA
+        end
       end
-
     end
 
     # @private TODO: this probably doesn't need to be a constant anyone can read
@@ -156,6 +163,36 @@ module OpenTok
       end
 
       JWT.encode(data_params, api_secret, 'HS256', header_fields={typ: 'JWT'})
+    end
+
+    GENERATE_VONAGE_TOKEN_LAMBDA = ->(api_key, api_secret, session_id, opts = {}) do
+      # normalize required data params
+      role = opts.fetch(:role, :publisher)
+      unless ROLES.has_key? role
+        raise "'#{role}' is not a recognized role"
+      end
+      unless Session.belongs_to_api_key? session_id.to_s, api_key
+        raise "Cannot generate token for a session_id that doesn't belong to api_key: #{api_key}"
+      end
+
+      claims = {
+        application_id: api_key,
+        scope: 'session.connect',
+        session_id: session_id,
+        role: role,
+        initial_layout_class_list: '',
+        sub: 'video',
+        acl: {
+          paths: {'/session/**' => {}}
+        }
+      }
+
+      claims[:data] = opts[:data] if opts[:data]
+      claims[:initial_layout_class_list] = opts[:initial_layout_class_list].join(' ') if opts[:initial_layout_class_list]
+      claims[:exp] = opts[:expire_time].to_i if opts[:expire_time]
+
+      claims[:private_key] = api_secret
+      Vonage::JWTBuilder.new(claims).jwt.generate
     end
 
     # this works when using extend TokenGenerator

--- a/lib/opentok/version.rb
+++ b/lib/opentok/version.rb
@@ -1,4 +1,4 @@
 module OpenTok
   # @private
-  VERSION = '4.13.0'
+  VERSION = '4.14.0'
 end

--- a/lib/opentok/websocket.rb
+++ b/lib/opentok/websocket.rb
@@ -27,6 +27,8 @@ module OpenTok
     # @option opts [Hash] :headers (optional) A hash of key-value pairs of headers to be sent to your WebSocket server with each message,
     #        with a maximum length of 512 bytes.
     # @option opts [Boolean] :bidirectional (optional) Whether the WebSocket connection should be bidirectional.
+    # @option opts [Integer] :audio_rate (optional) A number representing the audio sampling rate in Hz for the WebSocket stream.
+    #   - Must be one of: 8000, 16000, 24000
     def connect(session_id, token, websocket_uri, opts  = {})
       response = @client.connect_websocket(session_id, token, websocket_uri, opts)
     end

--- a/opentok.gemspec
+++ b/opentok.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable", "~> 2.3" #  2.3.0 <= version < 3.0.0
   spec.add_dependency "httparty", ">= 0.18.0"
   spec.add_dependency "activesupport", ">= 2.0"
-  spec.add_dependency "jwt", ">= 1.5.6"
+  spec.add_dependency "vonage-jwt", "~> 0.2.0"
 end

--- a/spec/cassettes/OpenTok_Connections/when_attempting_to_list_connections/should_return_all_connections.yml
+++ b/spec/cassettes/OpenTok_Connections/when_attempting_to_list_connections/should_return_all_connections.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/session/SESSIONID/connection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 May 2026 14:06:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 5,
+          "projectId" : "123456",
+          "sessionId" : "2_MX40NzIwMzJ-flR1ZSBPY3QgMjkgMTI6MTM6MjMgUERUIDIwMTN-MC45NDQ2MzE2NH4",
+          "items" : [{
+            "connectionId": "527775e1-626e-42c3-b0e8-e2122d20661a",
+            "createdAt": 1747655658197,
+            "connectionState": "Connected"
+          },{
+            "connectionId": "c6db93f0-8692-438c-944b-cfbaf577c878",
+            "createdAt": 1747655658227,
+            "connectionState": "Connected"
+          },{
+            "connectionId": "d95f6496-df6e-4f49-86d6-832e00303602",
+            "createdAt": 1747655658258,
+            "connectionState": "Connected"
+          },{
+            "connectionId": "15d73844-d503-4656-afdd-3eb10c96f4dc",
+            "createdAt": 1747655658300,
+            "connectionState": "Connected"
+          },{
+            "connectionId": "6f2a13b1-8d59-40ba-9719-891498aba89e",
+            "createdAt": 1747655658400,
+            "connectionState": "Connected"
+          }]
+        }
+  recorded_at: Tue, 19 May 2026 14:06:41 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/OpenTok_Connections/when_attempting_to_list_connections/should_return_connections_with_an_offset.yml
+++ b/spec/cassettes/OpenTok_Connections/when_attempting_to_list_connections/should_return_connections_with_an_offset.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/session/SESSIONID/connection?offset=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 May 2026 14:06:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 3,
+          "projectId" : "123456",
+          "sessionId" : "2_MX40NzIwMzJ-flR1ZSBPY3QgMjkgMTI6MTM6MjMgUERUIDIwMTN-MC45NDQ2MzE2NH4",
+          "items" : [{
+            "connectionId": "d95f6496-df6e-4f49-86d6-832e00303602",
+            "createdAt": 1747655658258,
+            "connectionState": "Connected"
+          },{
+            "connectionId": "15d73844-d503-4656-afdd-3eb10c96f4dc",
+            "createdAt": 1747655658300,
+            "connectionState": "Connected"
+          },{
+            "connectionId": "6f2a13b1-8d59-40ba-9719-891498aba89e",
+            "createdAt": 1747655658400,
+            "connectionState": "Connected"
+          }]
+        }
+  recorded_at: Tue, 19 May 2026 14:06:41 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/OpenTok_Connections/when_attempting_to_list_connections/should_return_count_number_of_connections.yml
+++ b/spec/cassettes/OpenTok_Connections/when_attempting_to_list_connections/should_return_count_number_of_connections.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/session/SESSIONID/connection?count=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 May 2026 14:06:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 2,
+          "projectId" : "123456",
+          "sessionId" : "2_MX40NzIwMzJ-flR1ZSBPY3QgMjkgMTI6MTM6MjMgUERUIDIwMTN-MC45NDQ2MzE2NH4",
+          "items" : [{
+            "connectionId": "527775e1-626e-42c3-b0e8-e2122d20661a",
+            "createdAt": 1747655658197,
+            "connectionState": "Connected"
+          },{
+            "connectionId": "c6db93f0-8692-438c-944b-cfbaf577c878",
+            "createdAt": 1747655658227,
+            "connectionState": "Connected"
+          }]
+        }
+  recorded_at: Tue, 19 May 2026 14:06:41 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/OpenTok_Connections/when_attempting_to_list_connections/should_return_part_of_the_connections_when_using_offset_and_count.yml
+++ b/spec/cassettes/OpenTok_Connections/when_attempting_to_list_connections/should_return_part_of_the_connections_when_using_offset_and_count.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opentok.com/v2/project/123456/session/SESSIONID/connection?count=2&offset=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/<%= version %>
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 19 May 2026 14:06:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "count" : 2,
+          "projectId" : "123456",
+          "sessionId" : "2_MX40NzIwMzJ-flR1ZSBPY3QgMjkgMTI6MTM6MjMgUERUIDIwMTN-MC45NDQ2MzE2NH4",
+          "items" : [{
+            "connectionId": "c6db93f0-8692-438c-944b-cfbaf577c878",
+            "createdAt": 1747655658227,
+            "connectionState": "Connected"
+          },{
+            "connectionId": "d95f6496-df6e-4f49-86d6-832e00303602",
+            "createdAt": 1747655658258,
+            "connectionState": "Connected"
+          }]
+        }
+  recorded_at: Tue, 19 May 2026 14:06:41 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions.yml
@@ -13,6 +13,7 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
       Accept: "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name.yml
@@ -15,6 +15,7 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name_and_resolution.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_name_and_resolution.yml
@@ -15,6 +15,7 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_resolution.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_always_archived_sessions_with_a_set_archive_resolution.yml
@@ -15,6 +15,7 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_default_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_default_sessions.yml
@@ -15,6 +15,7 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_default_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_default_sessions.yml
@@ -11,8 +11,10 @@ http_interactions:
       - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
-      Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-      Accept: "*/*"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_e2ee_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_e2ee_sessions.yml
@@ -13,6 +13,7 @@ http_interactions:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
       Accept: "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions.yml
@@ -12,7 +12,8 @@ http_interactions:
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-      Accept: "*/*"  
+      Accept: "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_for_invalid_media_modes.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_for_invalid_media_modes.yml
@@ -12,7 +12,8 @@ http_interactions:
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-      Accept: "*/*"  
+      Accept: "*/*"
+      Content-Type: "application/x-www-form-urlencoded"  
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_with_a_location_hint.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_relayed_media_sessions_with_a_location_hint.yml
@@ -12,7 +12,8 @@ http_interactions:
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-      Accept: "*/*"  
+      Accept: "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions.yml
@@ -12,7 +12,8 @@ http_interactions:
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-      Accept: "*/*"  
+      Accept: "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions_with_a_location_hint.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_routed_media_sessions_with_a_location_hint.yml
@@ -12,7 +12,8 @@ http_interactions:
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-      Accept: "*/*"  
+      Accept: "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_sessions_with_a_location_hint.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/_create_session/creates_sessions_with_a_location_hint.yml
@@ -12,7 +12,8 @@ http_interactions:
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-      Accept: "*/*"  
+      Accept: "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/with_an_addendum_to_the_user_agent_string/should_append_the_addendum_to_the_user_agent_header.yml
+++ b/spec/cassettes/OpenTok_OpenTok/when_initialized_properly/with_an_addendum_to_the_user_agent_string/should_append_the_addendum_to_the_user_agent_header.yml
@@ -12,7 +12,8 @@ http_interactions:
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Accept-Encoding: "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-      Accept: "*/*"  
+      Accept: "*/*"
+      Content-Type: "application/x-www-form-urlencoded"
   response:
     status:
       code: 200

--- a/spec/opentok/connection_spec.rb
+++ b/spec/opentok/connection_spec.rb
@@ -14,25 +14,73 @@ describe OpenTok::Connections do
   let(:session_id) { "SESSIONID" }
   let(:connection_id) { "CONNID" }
   let(:opentok) { OpenTok::OpenTok.new api_key, api_secret }
-  let(:connection) { opentok.connections }
+  let(:connections) { opentok.connections }
 
-  subject { connection }
+  subject { connections }
 
 
-  it 'raise an error on nil session_id' do
+  it 'raises an error on nil session_id when attempting to force disconnect' do
     expect {
-      connection.forceDisconnect(nil,connection_id)
+      connections.forceDisconnect(nil,connection_id)
     }.to raise_error(ArgumentError)
   end
 
-  it 'raise an error on nil connection_id' do
+  it 'raises an error on nil connection_id when attempting to force disconnect' do
     expect {
-      connection.forceDisconnect(session_id,nil)
+      connections.forceDisconnect(session_id,nil)
     }.to raise_error(ArgumentError)
   end
 
   it "forces a connection to be terminated", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
-    response = connection.forceDisconnect(session_id, connection_id)
+    response = connections.forceDisconnect(session_id, connection_id)
     expect(response).not_to be_nil
+  end
+
+  context "when attempting to list connections" do
+    it 'raises an error on nil session_id' do
+      expect {
+        connections.list(nil)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an error with count too low' do
+      expect {
+        connections.list(session_id, :count => 0)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an error with count too high' do
+      expect {
+        connections.list(session_id, :count => 1001)
+      }.to raise_error(ArgumentError)
+    end
+
+    it "should return all connections", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+      connections_list = connections.list(session_id)
+      expect(connections_list).to be_an_instance_of OpenTok::ConnectionList
+      expect(connections_list.total).to eq 5
+      expect(connections_list.count).to eq 5
+    end
+
+    it "should return connections with an offset", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+      connections_list = connections.list(session_id, :offset => 2)
+      expect(connections_list).to be_an_instance_of OpenTok::ConnectionList
+      expect(connections_list.total).to eq 3
+      expect(connections_list.count).to eq 3
+    end
+
+    it "should return count number of connections", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+      connections_list = connections.list(session_id, :count => 2)
+      expect(connections_list).to be_an_instance_of OpenTok::ConnectionList
+      expect(connections_list.total).to eq 2
+      expect(connections_list.count).to eq 2
+    end
+
+    it "should return part of the connections when using offset and count", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"} } do
+      connections_list = connections.list(session_id, :offset => 1, :count => 2)
+      expect(connections_list).to be_an_instance_of OpenTok::ConnectionList
+      expect(connections_list.total).to eq 2
+      expect(connections_list.count).to eq 2
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'webmock/rspec'
 VCR.configure do |c|
   c.cassette_library_dir     = 'spec/cassettes'
   c.hook_into                :webmock
-  c.default_cassette_options = { :match_requests_on => [:method, :uri, :query, :body, :headers] }
+  c.default_cassette_options = { :match_requests_on => [:method, :uri, :query, :body] }
   c.configure_rspec_metadata!
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'webmock/rspec'
 VCR.configure do |c|
   c.cassette_library_dir     = 'spec/cassettes'
   c.hook_into                :webmock
-  c.default_cassette_options = { :match_requests_on => [:method, :uri, :query, :body] }
+  c.default_cassette_options = { :match_requests_on => [:method, :uri, :query, :body, :headers] }
   c.configure_rspec_metadata!
 end
 


### PR DESCRIPTION
This PR updates the SDK in order to:

- Allow the use of Vonage Video API endpoints and credentials
- Add an endpoint for listing Connections to a Session
- Support the 24KHz `audio_rate` for WebSocket connections