### PR TITLE
feat: Add Audio Transport Support to Websocket Implementation

### DIFF
--- a/lib/opentok/websocket.rb
+++ b/lib/opentok/websocket.rb
@@ -29,11 +29,11 @@ module OpenTok
     # @option opts [Boolean] :bidirectional (optional) Whether the WebSocket connection should be bidirectional.
     # @option opts [Integer] :audio_rate (optional) A number representing the audio sampling rate in Hz for the WebSocket stream.
     #   - Must be one of: 8000, 16000, 24000
-    # @option opts [Hash] :audio_transport (optional) A hash that configures how audio is serialized on the WebSocket wire. By default, audio is sent as raw binary PCM 16-bit frames. For example:
+    # @option opts [Hash] :audio_transport (optional) A hash that configures how audio is serialized on the WebSocket wire. By default, audio is sent as raw binary PCM 16-bit frames.
     # @option opts[:audio_transport] [String] :transport (optional) The transport type for the audio data. Must be one of: "json", "binary".
     # @option opts[:audio_transport] [String] :encoding (optional) The encoding type for the audio data. Required when transport is "json". Must be one of: "base64".
-    # @option opts[:audio_transport] [String] :audio_field (optional)  The JSON key for the outbound audio data. The default value is "audio".
-    # @option opts[:audio_transport] [String] :receive_audio_field (optional) The JSON key for inbound audio data (when bidirectional is enabled). Defaults to the same value as `audio_field`
+    # @option opts[:audio_transport] [String] :audio_field (optional) The JSON key for the outbound audio data. The default value is "audio".
+    # @option opts[:audio_transport] [String] :receive_audio_field (optional) The JSON key for inbound audio data (when bidirectional is enabled). Defaults to the same value as `audio_field`.
     # @option opts[:audio_transport] [Hash] :static_fields (optional) An optional hash of extra key-value pairs included in every outbound JSON audio message.
     def connect(session_id, token, websocket_uri, opts  = {})
       response = @client.connect_websocket(session_id, token, websocket_uri, opts)

--- a/lib/opentok/websocket.rb
+++ b/lib/opentok/websocket.rb
@@ -29,6 +29,12 @@ module OpenTok
     # @option opts [Boolean] :bidirectional (optional) Whether the WebSocket connection should be bidirectional.
     # @option opts [Integer] :audio_rate (optional) A number representing the audio sampling rate in Hz for the WebSocket stream.
     #   - Must be one of: 8000, 16000, 24000
+    # @option opts [Hash] :audioTransport (optional) A hash that configures how audio is serialized on the WebSocket wire. By default, audio is sent as raw binary PCM 16-bit frames. For example:
+    # @option opts[:audioTransport] [String] :transport (optional) The transport type for the audio data. Must be one of: "json", "binary".
+    # @option opts[:audioTransport] [String] :encoding (optional) The encoding type for the audio data. Required when transport is "json". Must be one of: "base64".
+    # @option opts[:audioTransport] [String] :audio_field (optional)  The JSON key for the outbound audio data. The default value is "audio".
+    # @option opts[:audioTransport] [String] :receive_audio_field (optional) The JSON key for inbound audio data (when bidirectional is enabled). Defaults to the same value as `audio_field`
+    # @option opts[:audioTransport] [Hash] :static_fields (optional) An optional hash of extra key-value pairs included in every outbound JSON audio message.
     def connect(session_id, token, websocket_uri, opts  = {})
       response = @client.connect_websocket(session_id, token, websocket_uri, opts)
     end

--- a/lib/opentok/websocket.rb
+++ b/lib/opentok/websocket.rb
@@ -29,12 +29,12 @@ module OpenTok
     # @option opts [Boolean] :bidirectional (optional) Whether the WebSocket connection should be bidirectional.
     # @option opts [Integer] :audio_rate (optional) A number representing the audio sampling rate in Hz for the WebSocket stream.
     #   - Must be one of: 8000, 16000, 24000
-    # @option opts [Hash] :audioTransport (optional) A hash that configures how audio is serialized on the WebSocket wire. By default, audio is sent as raw binary PCM 16-bit frames. For example:
-    # @option opts[:audioTransport] [String] :transport (optional) The transport type for the audio data. Must be one of: "json", "binary".
-    # @option opts[:audioTransport] [String] :encoding (optional) The encoding type for the audio data. Required when transport is "json". Must be one of: "base64".
-    # @option opts[:audioTransport] [String] :audio_field (optional)  The JSON key for the outbound audio data. The default value is "audio".
-    # @option opts[:audioTransport] [String] :receive_audio_field (optional) The JSON key for inbound audio data (when bidirectional is enabled). Defaults to the same value as `audio_field`
-    # @option opts[:audioTransport] [Hash] :static_fields (optional) An optional hash of extra key-value pairs included in every outbound JSON audio message.
+    # @option opts [Hash] :audio_transport (optional) A hash that configures how audio is serialized on the WebSocket wire. By default, audio is sent as raw binary PCM 16-bit frames. For example:
+    # @option opts[:audio_transport] [String] :transport (optional) The transport type for the audio data. Must be one of: "json", "binary".
+    # @option opts[:audio_transport] [String] :encoding (optional) The encoding type for the audio data. Required when transport is "json". Must be one of: "base64".
+    # @option opts[:audio_transport] [String] :audio_field (optional)  The JSON key for the outbound audio data. The default value is "audio".
+    # @option opts[:audio_transport] [String] :receive_audio_field (optional) The JSON key for inbound audio data (when bidirectional is enabled). Defaults to the same value as `audio_field`
+    # @option opts[:audio_transport] [Hash] :static_fields (optional) An optional hash of extra key-value pairs included in every outbound JSON audio message.
     def connect(session_id, token, websocket_uri, opts  = {})
       response = @client.connect_websocket(session_id, token, websocket_uri, opts)
     end

--- a/spec/cassettes/OpenTok_WebSocket/receives_a_valid_response_with_opts.yml
+++ b/spec/cassettes/OpenTok_WebSocket/receives_a_valid_response_with_opts.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.opentok.com/v2/project/123456/connect
     body:
       encoding: UTF-8
-      string: '{"sessionId":"SESSIONID","token":"TOKENID","websocket":{"uri":"ws://service.com/wsendpoint","streams":["123456"],"headers":{"foo":"bar"},"bidirectional":true}}'
+      string: '{"sessionId":"SESSIONID","token":"TOKENID","websocket":{"uri":"ws://service.com/wsendpoint","streams":["123456"],"headers":{"foo":"bar"},"bidirectional":true,"audioTransport":{"transport":"json","encoding":"base64","audio_field":"audio","receive_audio_field":"audio","static_fields":{"foo":"bar"}}}}'
     headers:
       User-Agent:
       - OpenTok-Ruby-SDK/<%= version %>

--- a/spec/opentok/websocket_spec.rb
+++ b/spec/opentok/websocket_spec.rb
@@ -28,7 +28,16 @@ describe OpenTok::WebSocket do
     opts = {
       "streams" => ["123456"],
       "headers" => {"foo" => "bar"},
-      "bidirectional" => true
+      "bidirectional" => true,
+      "audioTransport" => {
+        "transport" => "json",
+        "encoding" => "base64",
+        "audio_field" => "audio",
+        "receive_audio_field" => "audio",
+        "static_fields" => {
+          "foo" => "bar"
+        }
+      }
     }
 
     response = websocket.connect(session_id, expiring_token, websocket_uri, opts)

--- a/spec/opentok/websocket_spec.rb
+++ b/spec/opentok/websocket_spec.rb
@@ -29,7 +29,7 @@ describe OpenTok::WebSocket do
       "streams" => ["123456"],
       "headers" => {"foo" => "bar"},
       "bidirectional" => true,
-      "audioTransport" => {
+      "audio_transport" => {
         "transport" => "json",
         "encoding" => "base64",
         "audio_field" => "audio",


### PR DESCRIPTION
Since the `WebSocket#connect` method accepts a generic Hash of `opts`, the method already technically supports the new params. This PR therefore:

- Updates an existing unit test for the method to include the new params
- Updates the YARD doc comments for the method to include the new params

This PR completes https://jira.vonage.com/browse/DEVX-11297