### PR TITLE
feat: Add Post Call Transcription

### DIFF
--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -83,11 +83,15 @@ module OpenTok
     #   value is 100,000 and the maximum is 6,000,000. This option is only valid for composed archives. Set the maximum video bitrate
     #   to control the size of the composed archive. This maximum bitrate applies to the video bitrate only. If the output archive has
     #   audio, those bits will be excluded from the limit.
-    #
     # @option options [Integer] :quantization_parameter (Optional) The quantization parameter (QP) is an optional video encoding value allowed for composed archiving,
     #   smaller values generate higher quality and larger archives, larger values generate lower quality and smaller archives, QP uses variable bitrate (VBR). The minimum
     #   value is 15 and the maximum is 40.
     #   This parameter is mutually exclusive with the max_bitrate parameter.
+    # @option options [Boolean] :has_transcription (Optional) Whether the archive will have a transcription of the audio of the session (true) or not (false, the default).
+    # @option options [Hash] :transcription_properties (Optional) A hash of specific transcription settings.
+    # @option options[:transcription_properties] [String] 'primaryLanguageCode' (Optional) The primary language spoken in the archive to be transcribed, in BCP-47 format, e.g. en-US, es-ES or pt-BR.
+    #   @see https://developer.vonage.com/en/api/video#post-v2-project-application_id-archive for a full list of supported languages.
+    # @option options[:transcription_properties] [Boolean] 'hasSummary' (Optional) Whether the transcription should include a summary of the session (true) or not (false, the default).
     #
     # @return [Archive] The Archive object, which includes properties defining the archive,
     #   including the archive ID.

--- a/lib/opentok/archives.rb
+++ b/lib/opentok/archives.rb
@@ -116,7 +116,9 @@ module OpenTok
         :multi_archive_tag,
         :stream_mode,
         :max_bitrate,
-        :quantization_parameter
+        :quantization_parameter,
+        :has_transcription,
+        :transcription_properties
       ]
       opts = options.inject({}) do |m,(k,v)|
         if valid_opts.include? k.to_sym

--- a/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_transcription_enabled_and_transcription_settings_specified.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_transcription_enabled_and_transcription_settings_specified.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.opentok.com/v2/project/123456/archive
+    body:
+      encoding: UTF-8
+      string: '{"sessionId":"SESSIONID", "hasTranscription":true,"transcriptionProperties":{"primaryLanguageCode":"en-US","hasSummary":true}}'
+    headers:
+      User-Agent:
+      - OpenTok-Ruby-SDK/4.14.0-Ruby-Version-3.4.0-p-1
+      X-Opentok-Auth:
+      - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 18 Aug 2026 15:46:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "createdAt" : 1395183243556,
+          "duration" : 0,
+          "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+          "name" : "",
+          "partnerId" : 123456,
+          "reason" : "",
+          "sessionId" : "SESSIONID",
+          "size" : 0,
+          "status" : "started",
+          "url" : null,
+          "hasTranscription": true,
+          "transcriptionProperties": {
+            "primaryLanguageCode": "en-US",
+            "hasSummary": true
+          }
+        }
+  recorded_at: Tue, 18 Aug 2026 15:46:06 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_transcription_enabled_and_transcription_settings_specified.yml
+++ b/spec/cassettes/OpenTok_Archives/should_create_an_archive_with_transcription_enabled_and_transcription_settings_specified.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: https://api.opentok.com/v2/project/123456/archive
     body:
       encoding: UTF-8
-      string: '{"sessionId":"SESSIONID", "hasTranscription":true,"transcriptionProperties":{"primaryLanguageCode":"en-US","hasSummary":true}}'
+      string: '{"sessionId":"SESSIONID","hasTranscription":true,"transcriptionProperties":{"primaryLanguageCode":"en-US","hasSummary":true}}'
     headers:
       User-Agent:
-      - OpenTok-Ruby-SDK/4.14.0-Ruby-Version-3.4.0-p-1
+      - OpenTok-Ruby-SDK/<%= version %>
       X-Opentok-Auth:
       - eyJpc3QiOiJwcm9qZWN0IiwiYWxnIjoiSFMyNTYifQ.eyJpc3MiOiIxMjM0NTYiLCJpYXQiOjE0OTI1MTA2NjAsImV4cCI6MTQ5MjUxMDk2MH0.BplMVhJWx4ld7KLKXqEmow6MjNPPFw9W8IHCMfeb120
       Content-Type:
@@ -27,7 +27,7 @@ http_interactions:
       Date:
       - Tue, 18 Aug 2026 15:46:06 GMT
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Transfer-Encoding:
       - chunked
       Connection:

--- a/spec/opentok/archives_spec.rb
+++ b/spec/opentok/archives_spec.rb
@@ -119,6 +119,16 @@ describe OpenTok::Archives do
     expect(archive.session_id).to eq session_id
   end
 
+  it "should create an archive with transcription enabled and transcription settings specified", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" } } do
+    transcription_properties = {
+      'primaryLanguageCode' => 'en-US',
+      'hasSummary' => true
+    }
+    archive = archives.create session_id, :has_transcription => true, :transcription_properties => transcription_properties
+    expect(archive).to be_an_instance_of OpenTok::Archive
+    expect(archive.session_id).to eq session_id
+  end
+
   it "should stop archives", :vcr => { :erb => { :version => OpenTok::VERSION + "-Ruby-Version-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" } } do
     archive = archives.stop_by_id started_archive_id
     expect(archive).to be_an_instance_of OpenTok::Archive


### PR DESCRIPTION
This PR adds support for transcription settings when starting an archive recording. Specifically it:

- Updates the implementation of the `Archives#create` method to accept the new params
- Adds a new unit test to test the new params can be passed to the method
- Updates the YARD doc comments for the `Archives#create` method to document the new params

This PR completes https://jira.vonage.com/browse/DEVX-11323